### PR TITLE
[feat] 회원가입/로그인 API 호출 / [refactor] 위치정보 컴포넌트 분리

### DIFF
--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -1,9 +1,11 @@
 'use client';
 
 import '../../../../styles/mypage.css';
-import axios from 'axios';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import axios from 'axios';
+import getLocation from '@/app/_components/_user/GetLocation';
 import kakao from '../../../../../public/image/kakao.png';
 import naver from '../../../../../public/image/naver.png';
 import profile from '../../../../../public/image/profile.jpg';
@@ -46,42 +48,16 @@ export default function Info() {
       top: window.innerHeight / 2 - 600 / 2,
     });
   };
-  const handleGetCurrentLocation = () => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        async (position) => {
-          const { latitude, longitude } = position.coords;
 
-          try {
-            const response = await axios.get(
-              `/api/map-reversegeocode/gc?coords=${longitude},${latitude}&output=json`,
-              {
-                headers: {
-                  'X-NCP-APIGW-API-KEY-ID':
-                    process.env.NEXT_PUBLIC_MAP_CLIENT_ID,
-                  'X-NCP-APIGW-API-KEY':
-                    process.env.NEXT_PUBLIC_MAP_CLIENT_SECRET,
-                },
-              }
-            );
-            // 추후 확인 예정 CORS
-            const address = response.data.results[0].region;
-            setUserInfo((prevState) => ({
-              ...prevState,
-              location: address.area2.name,
-            }));
-          } catch (error) {
-            console.error('Error fetching address:', error);
-          }
-        },
-        (error) => {
-          console.error('Error getting location:', error);
-        }
-      );
-    } else {
-      alert('Geolocation is not supported by this browser.');
-    }
+  const handleGetCurrentLocation = async () => {
+    // 정말 재설정 할 것인지 물어보는 alert 추가
+    const location = await getLocation();
+    setUserInfo((prevState) => ({
+      ...prevState,
+      location: location,
+    }));
   };
+
   return (
     <main className="ml-[250px] px-[40px] py-[30px] min-h-[750px]">
       <h1 className="text-[32px] font-bold">회원 정보</h1>

--- a/dutchiepay/src/app/(routes)/signup/page.jsx
+++ b/dutchiepay/src/app/(routes)/signup/page.jsx
@@ -11,6 +11,7 @@ import PolicyDetail from '@/app/_components/_user/PolicyDetail';
 import axios from 'axios';
 import eyeClosed from '../../../../public/image/eyeClosed.svg';
 import eyeOpen from '../../../../public/image/eyeOpen.svg';
+import getLocation from '@/app/_components/_user/GetLocation';
 import kakao from '../../../../public/image/kakao.png';
 import logo from '../../../../public/image/logo.jpg';
 import naver from '../../../../public/image/naver.png';
@@ -35,6 +36,9 @@ export default function Signup() {
     criteriaMode: 'all',
     reValidateMode: 'onChange',
     shouldFocusError: true,
+    defaultValues: {
+      name: '',
+    },
   });
 
   const rEmail =
@@ -75,53 +79,28 @@ export default function Signup() {
     const { confirmPassword, policy, name = '', ...userData } = formData;
     const payload = {
       ...userData,
-      address,
+      location: address,
       name: name.trim() === '' ? null : name,
     };
     console.log(payload);
     try {
-      const response = await axios.post('/users/signup', payload);
-      console.log('회원가입 성공:', response.data);
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/users/signup`,
+        payload
+      );
     } catch (error) {
       console.error('회원가입 실패:', error);
     }
   };
 
-  const getLocation = () => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        async (position) => {
-          const { latitude, longitude } = position.coords;
-
-          try {
-            const response = await axios.get(
-              `/api/map-reversegeocode/gc?coords=${longitude},${latitude}&output=json`,
-              {
-                headers: {
-                  'X-NCP-APIGW-API-KEY-ID':
-                    process.env.NEXT_PUBLIC_MAP_CLIENT_ID,
-                  'X-NCP-APIGW-API-KEY':
-                    process.env.NEXT_PUBLIC_MAP_CLIENT_SECRET,
-                },
-              }
-            );
-            const address = response.data.results[0].region;
-            setAddress(address.area2.name);
-          } catch (error) {
-            console.error('주소 가져오기 오류:', error);
-          }
-        },
-        (error) => {
-          console.error('위치 가져오기 오류:', error);
-        }
-      );
-    } else {
-      alert('이 브라우저는 지오로케이션을 지원하지 않습니다.');
-    }
-  };
-
   useEffect(() => {
     getLocation();
+    const fetchLocation = async () => {
+      const location = await getLocation();
+      setAddress(location);
+    };
+
+    fetchLocation();
   }, []);
 
   return (

--- a/dutchiepay/src/app/_components/_user/GetLocation.jsx
+++ b/dutchiepay/src/app/_components/_user/GetLocation.jsx
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+export default function getLocation() {
+  return new Promise((resolve, reject) => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          const { latitude, longitude } = position.coords;
+
+          try {
+            const response = await axios.get(
+              `/api/map-reversegeocode/gc?coords=${longitude},${latitude}&output=json`,
+              {
+                headers: {
+                  'X-NCP-APIGW-API-KEY-ID':
+                    process.env.NEXT_PUBLIC_MAP_CLIENT_ID,
+                  'X-NCP-APIGW-API-KEY':
+                    process.env.NEXT_PUBLIC_MAP_CLIENT_SECRET,
+                },
+              }
+            );
+
+            resolve(response.data.results[0].region.area2.name);
+          } catch (error) {
+            resolve('위치 정보를 불러오는 도중 오류가 발생했습니다.');
+          }
+        },
+        (error) => {
+          resolve('위치 정보를 가져오지 못 했습니다.');
+        }
+      );
+    } else {
+      resolve('브라우저가 위치 정보를 지원하지 않습니다.');
+    }
+  });
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인
- [x] 리팩토링

## 반영 브랜치
ex) feat/회원가입_API -> main

## 변경 사항
1. 로그인 API 호출
2. 회원가입 API 호출
3. 회원가입/마이페이지 회원정보 페이지 내의 getLocation 함수를 컴포넌트화하여 재사용

## 테스트 결과
※ API 호출은 회의 시간에 함께 진행했던 내용이므로 결과를 생략합니다.

회원가입 페이지 접근 시 위치정보 불러오기
![image](https://github.com/user-attachments/assets/1ded5811-225c-4b7b-8d6b-e07f2b4ddc84)

default 값 = 평택시 -> 재설정 버튼 클릭 시 춘천시로 변경
![image](https://github.com/user-attachments/assets/a0cab3e9-9369-4ce3-9bf3-8020ddd9e600)

getLocation 함수 컴포넌트화
- Promise를 사용하여 값을 반환함으로써 위치정보를 불러온 뒤에 set 함수를 실행할 수 있도록 기존 함수 수정 (초기 undefined 값 나오지 않도록 설정)
- Promise 중 resolve를 반환하도록 구현 위치정보를 불러오지 못했을 때도 에러 문구를 표시하도록 resolve로 전달
- 위치 정보 에러 문구를 보다 명확히 하여 어떠한 오류로 불러오지 못했는지를 확실하게 표
![image](https://github.com/user-attachments/assets/8bdf7579-6133-451a-b4eb-597c06c163d8)


## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
