### PR TITLE
[fix] 수동 리디렉션 설정으로 변경

### DIFF
--- a/dutchiepay/next.config.mjs
+++ b/dutchiepay/next.config.mjs
@@ -9,15 +9,6 @@ const nextConfig = {
       },
     ];
   },
-  async redirects() {
-    return [
-      {
-        source: '/mypage',
-        destination: '/mypage/info',
-        permanent: true,
-      },
-    ];
-  },
   images: { unoptimized: true },
   output: 'export',
 };

--- a/dutchiepay/src/app/(routes)/mypage/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/page.jsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function Mypage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push('/mypage/info');
+  }, [router]);
+
+  return <div className="h-[750px]"></div>;
+}

--- a/dutchiepay/src/app/(routes)/mypage/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/page.jsx
@@ -10,5 +10,5 @@ export default function Mypage() {
     router.push('/mypage/info');
   }, [router]);
 
-  return <div className="h-[750px]"></div>;
+  return <div className="h-[740px]"></div>;
 }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) fix/redirect-static -> main

## 변경 사항
export 설정 시 커스텀 리디렉션 사용 불가능으로 인해 수동 리디렉션 설정으로 변경

## 테스트 결과
1. 'next/navigation'의 redirect를 이용해 /mypage 접속 시 리디렉션을 진행하려고 했으나 아래와 같이 /mypage에 접속해 있는 동안 content 영역이 없어 footer가 위로 올라오고 sidebar에 가려지는 현상이 잠깐 표시되는 경우가 발생 -> 속도 저하(slow 4G)를 하지 않을 때도 footer의 일부분이 깜빡이는 것으로 보임 (recirect는 return 영역에 접근 불가능하여 height를 지정할 수 없음)

![스크린샷 2024-09-13 115621](https://github.com/user-attachments/assets/0a1a0dfa-d557-46f6-8a4a-d9d1169fb227)

2. 'next/navigation'의 useRouter를 이용해 클라이언트 측에서 /mypage 접속 시 /mypage/info로 route 되도록 설정하고 content의 height를 지정하여 /mypage에서도 content 영역이 확보되는 방법으로 결정 
![image](https://github.com/user-attachments/assets/4c20fcc3-2365-4da5-b63b-ee938eff02a7)

(※ URL 참고) /mypage 접근 시 content 확보 (첨부된 이미지는 마지막 commit 이전 기준으로 현재는 footer가 하단에 붙도록 수정, 디바이스마다 다르게 표시될 수 있음. calc 지원 불가능으로 추후 방법 고안 예정) 
![스크린샷 2024-09-13 115830](https://github.com/user-attachments/assets/dbf544f9-aaf5-4b9f-ad00-16cabad71eb0)
![스크린샷 2024-09-13 115844](https://github.com/user-attachments/assets/337a9c5a-f3f6-4eb0-957b-4cd01a02eabc)

