### PR TITLE
[feat] 로그인 API, 로그인 정보 redux 및 쿠키 저장

### DIFF
--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -21,7 +21,9 @@
         "react-quill": "^2.0.0",
         "react-redux": "^9.1.2",
         "react-slick": "^0.30.2",
-        "slick-carousel": "^1.8.1"
+        "redux-persist": "^6.0.0",
+        "slick-carousel": "^1.8.1",
+        "universal-cookie": "^7.2.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.9.0",
@@ -7151,6 +7153,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
@@ -9491,7 +9498,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15878,6 +15884,14 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -18065,6 +18079,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.0.tgz",
+      "integrity": "sha512-PvcyflJAYACJKr28HABxkGemML5vafHmiL4ICe3e+BEKXRMt0GaFLZhAwgv637kFFnnfiSJ8e6jknrKkMrU+PQ==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.6.0"
       }
     },
     "node_modules/universalify": {

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -24,7 +24,9 @@
     "react-quill": "^2.0.0",
     "react-redux": "^9.1.2",
     "react-slick": "^0.30.2",
-    "slick-carousel": "^1.8.1"
+    "redux-persist": "^6.0.0",
+    "slick-carousel": "^1.8.1",
+    "universal-cookie": "^7.2.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.9.0",

--- a/dutchiepay/src/app/(routes)/login/page.jsx
+++ b/dutchiepay/src/app/(routes)/login/page.jsx
@@ -72,14 +72,10 @@ export default function Login() {
         })
       );
 
-      if (isRemeberMe) {
-        // 자동로그인 - 지속 쿠키로 저장
-        const expires = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30일동안 쿠키 저장 (임시 변경 예정)
-        cookies.set('refresh', response.data.refresh, { path: '/', expires });
-      } else {
-        // 자동로그인 X - 세션 쿠키로 저장
-        cookies.set('refresh', response.data.refresh, { path: '/' });
-      }
+      const expires = isRemeberMe
+        ? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+        : undefined;
+      cookies.set('refresh', response.data.refresh, { path: '/', expires });
 
       router.push('/');
     } catch {

--- a/dutchiepay/src/app/(routes)/login/page.jsx
+++ b/dutchiepay/src/app/(routes)/login/page.jsx
@@ -3,26 +3,34 @@
 import '@/styles/user.css';
 import '@/styles/globals.css';
 
+import Cookies from 'universal-cookie';
 import Image from 'next/image';
 import Link from 'next/link';
 import axios from 'axios';
 import eyeClosed from '../../../../public/image/eyeClosed.svg';
 import eyeOpen from '../../../../public/image/eyeOpen.svg';
 import kakao from '../../../../public/image/kakao.png';
+import { login } from '@/redux/slice/loginSlice';
 import logo from '../../../../public/image/logo.jpg';
 import naver from '../../../../public/image/naver.png';
+import { useDispatch } from 'react-redux';
 import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function Login() {
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const cookies = new Cookies();
   const [isVisible, setIsVisible] = useState(false);
-  const loginType = 'naver';
+  const [loginType, setLoginType] = useState(''); // email/kakao/naver
+  const [isRemeberMe, setIsRememberMe] = useState(false); // 자동로그인 체크 여부
 
   const {
     register,
     watch,
     handleSubmit,
-    formState: { errors, touchedFields, isSubmitted },
+    formState: { errors, isSubmitted },
   } = useForm({
     mode: 'onSubmit',
     criteriaMode: 'all',
@@ -37,11 +45,46 @@ export default function Login() {
   const password = watch('password');
 
   const onSubmit = async (formData) => {
-    const { ...userData } = formData;
-    const payload = {
-      ...userData,
-    };
-    console.log(payload);
+    try {
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/users/login`,
+        formData
+      );
+
+      const userInfo = {
+        isLoggedIn: true,
+        loginType: response.data.type || 'email',
+        user: {
+          userId: response.data.userId,
+          nickname: response.data.nickname,
+          profileImage: response.data.profileImage,
+          location: response.data.location,
+          isCertified: response.data.isCertified,
+        },
+        access: response.data.access,
+      };
+
+      dispatch(
+        login({
+          loginType: userInfo.loginType,
+          user: userInfo.user,
+          access: userInfo.access,
+        })
+      );
+
+      if (isRemeberMe) {
+        // 자동로그인 - 지속 쿠키로 저장
+        const expires = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30일동안 쿠키 저장 (임시 변경 예정)
+        cookies.set('refresh', response.data.refresh, { path: '/', expires });
+      } else {
+        // 자동로그인 X - 세션 쿠키로 저장
+        cookies.set('refresh', response.data.refresh, { path: '/' });
+      }
+
+      router.push('/');
+    } catch {
+      // 오류 발생
+    }
   };
 
   const handleEnter = (e) => {
@@ -107,14 +150,18 @@ export default function Login() {
               <button type="submit" className="user__button-blue">
                 로그인
               </button>
-              <Link href="/signup" className="user__button-white">
+              <Link href="/signup" className="user__button-white" role="button">
                 회원가입
               </Link>
             </div>
 
             <div className="flex justify-between items-center mt-[8px] mb-[32px]">
               <div className="flex items-center gap-[8px]">
-                <input type="checkbox" className="login__checkbox" />
+                <input
+                  type="checkbox"
+                  className="login__checkbox"
+                  onChange={(e) => setIsRememberMe(e.target.checked)}
+                />
                 <label className="text-gray--500 text-sm">자동 로그인</label>
               </div>
               <Link

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -2,10 +2,8 @@
 
 import '../../../styles/header.css';
 
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { useEffect, useState, useMemo, useCallback } from 'react';
-
 import { usePathname, useRouter } from 'next/navigation';
 
 import Image from 'next/image';
@@ -36,12 +34,9 @@ export default function Header() {
     return '';
   }, [pathname]);
 
-  const handleProfileClick = useCallback(() => {
-    router.push('/mypage');
-  }, [router]);
-
   const handleLogout = useCallback(() => {
     dispatch(logout());
+    cookies.remove('refresh', { path: '/' });
   }, [dispatch]);
 
   const handleKeyDown = useCallback(
@@ -69,9 +64,7 @@ export default function Header() {
             {isLoggedIn ? (
               <>
                 <li className="nav-item">
-                  <span className="font-bold text-xs">
-                    {user?.nickName || '사용자'}님
-                  </span>
+                  <span className="font-bold text-xs">{user?.nickname}님</span>
                 </li>
                 <li className="nav-item">
                   <button onClick={handleLogout} className="text-xs">
@@ -152,7 +145,7 @@ export default function Header() {
                 alt="profile"
                 width={55}
                 height={55}
-                onClick={handleProfileClick}
+                onClick={() => router.push('/mypage')}
               />
             </div>
           )}

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { usePathname, useRouter } from 'next/navigation';
 
+import Cookies from 'universal-cookie';
 import Image from 'next/image';
 import Link from 'next/link';
 import chat from '../../../../public/image/chat.svg';
@@ -19,6 +20,7 @@ export default function Header() {
   const user = useSelector((state) => state.login.user);
   const dispatch = useDispatch();
   const router = useRouter();
+  const cookies = new Cookies();
 
   const pathname = usePathname();
 

--- a/dutchiepay/src/app/_components/_layout/Sidebar.jsx
+++ b/dutchiepay/src/app/_components/_layout/Sidebar.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import '../../../styles/mypage.css';
 
 import Image from 'next/image';
@@ -10,20 +12,23 @@ import post from '../../../../public/image/post.svg';
 import profile from '../../../../public/image/profile.jpg';
 import question from '../../../../public/image/question.svg';
 import review from '../../../../public/image/review.svg';
+import { useSelector } from 'react-redux';
 import user from '../../../../public/image/user.svg';
 
 export default function Sidebar() {
+  const userInfo = useSelector((state) => state.login.user);
+
   return (
     <aside className="w-[250px] h-[730px] bg-white border-r p-[16px] mb-[70px] flex flex-col items-center gap-[32px] fixed">
       <div className="flex flex-col items-center">
         <Image
           className="w-[120px] h-[120px] rounded-full border mb-[12px]"
-          src={profile}
+          src={userInfo?.profileImage || profile}
           alt="profile"
           width={120}
           height={120}
         />
-        <strong>한유진</strong>
+        <strong>{userInfo?.nickname}</strong>
       </div>
       <ul>
         <li className="mypage-sidebar-navbar__item">

--- a/dutchiepay/src/app/layoutClient.js
+++ b/dutchiepay/src/app/layoutClient.js
@@ -2,12 +2,14 @@
 
 import '../styles/globals.css';
 
+import { persistor, store } from '@/redux/store';
+
 import Floating from './_components/_layout/Floating';
 import Footer from './_components/_layout/Footer';
 import Header from './_components/_layout/Header';
+import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import UpDownButton from './_components/_layout/UpDownButton';
-import store from '@/redux/store';
 import { usePathname } from 'next/navigation';
 
 export default function RootLayoutClient({ children }) {
@@ -25,14 +27,16 @@ export default function RootLayoutClient({ children }) {
 
   return (
     <Provider store={store}>
-      {!rhideHeader && <Header />}
+      <PersistGate loading={null} persistor={persistor}>
+        {!rhideHeader && <Header />}
 
-      <main className={`layout ${!rhideHeader ? 'mt-[155px]' : ''}`}>
-        {children}
-        {!rhideFloating && <Floating />}
-        <UpDownButton />
-      </main>
-      {!rhideFooter && <Footer />}
+        <main className={`layout ${!rhideHeader ? 'mt-[155px]' : ''}`}>
+          {children}
+          {!rhideFloating && <Floating />}
+          <UpDownButton />
+        </main>
+        {!rhideFooter && <Footer />}
+      </PersistGate>
     </Provider>
   );
 }

--- a/dutchiepay/src/redux/slice/loginSlice.js
+++ b/dutchiepay/src/redux/slice/loginSlice.js
@@ -3,12 +3,15 @@ import { createSlice } from '@reduxjs/toolkit';
 // 초기 상태 정의
 const initialState = {
   isLoggedIn: false,
-  user: null, // 사용자 정보가 필요하다면 여기에 저장
-  jwt: {
-    access: '',
-    expirationTime: '',
+  loginType: null,
+  user: {
+    userId: null,
+    nickname: null,
+    profileImage: null,
+    location: null,
+    isCertified: null,
   },
-  // 인증 여부
+  access: '',
 };
 
 // 로그인 슬라이스 생성
@@ -18,13 +21,22 @@ const loginSlice = createSlice({
   reducers: {
     login(state, action) {
       state.isLoggedIn = true;
-      state.user = action.payload; // 로그인 시 사용자 정보를 payload로 받아서 저장
-      state.jwt = action.payload.jwt;
+      state.loginType = action.payload.loginType;
+      state.user = action.payload.user;
+      state.access = action.payload.access;
     },
+
     logout(state) {
       state.isLoggedIn = false;
-      state.user = null; // 로그아웃 시 사용자 정보 초기화 initialState.user
-      state.jwt = { access: '', expirationTime: '' };
+      state.loginType = null;
+      state.user = {
+        userId: null,
+        nickname: null,
+        profileImage: null,
+        location: null,
+        isCertified: null,
+      };
+      state.access = '';
     },
   },
 });

--- a/dutchiepay/src/redux/store.js
+++ b/dutchiepay/src/redux/store.js
@@ -1,11 +1,27 @@
-import { configureStore } from "@reduxjs/toolkit";
-import loginReducer from "../redux/slice/loginSlice";
+import { persistReducer, persistStore } from 'redux-persist';
+
+import { configureStore } from '@reduxjs/toolkit';
+import loginReducer from '../redux/slice/loginSlice';
+import sessionStorage from 'redux-persist/lib/storage/session';
+
+const persistConfig = {
+  key: 'root',
+  storage: sessionStorage,
+};
+
+const persistedReducer = persistReducer(persistConfig, loginReducer);
 
 // Redux 스토어 생성
 const store = configureStore({
   reducer: {
-    login: loginReducer,
+    login: persistedReducer,
   },
+  middleware: (defaultMiddleware) =>
+    defaultMiddleware({
+      serializableCheck: false,
+    }), // serializableCheck를 사용하지 않도록 함
 });
 
-export default store;
+const persistor = persistStore(store);
+
+export { store, persistor };


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/login -> main

## 변경 사항
1. 로그인 API 호출
2. 로그인으로 받은 사용자 정보 redux 저장
3. 자동로그인 체크 여부에 따른 refresh 쿠키 저장 (세션/지속 쿠키) - 지속 쿠키의 경우 30일동안 저장되도록 임시 구현
4. 로그아웃 시 refresh 토큰 삭제 (로그아웃 api 호출  X)
5. redux-persist로 sessionstorage에 redux 변수 저장으로 데이터 유지
6. header/sidebar 사용자 정보 표시

## 테스트 결과
로그인 시 header에 닉네임 및 프로필 이미지 표시 (현재 default profileImage는 임시 상태)
![image](https://github.com/user-attachments/assets/8154a531-60b6-42fb-84e7-077741fc8307)

sidebar에서 닉네임과 프로필 이미지 redux 값으로 표시
![image](https://github.com/user-attachments/assets/6677b40e-9309-43da-b9c4-d7d9c218ccf7)

serializability dev check middleware가 자동적으로 실행되어 serializableCheck를 false로 지정해 해
![image](https://github.com/user-attachments/assets/de494d6c-c287-40a9-900e-731429e50370)

## ETC
[serializableCheck 관련 에러 해결](https://github.com/rt2zz/redux-persist/issues/988)

+ 이전 회의에서 redux를 local에 저장하는 것으로 결정했으나 이 경우, 자동로그인으로 설정하지 않은 회원이 로그아웃하고 브라우저를 닫았을 때, redux 관련 데이터들은 유지되지만 refresh가 사라지는 상황이 발생하여 session에 저장하도록 수정하였습니다.

