### PR TITLE
[feat] 파일 불러오기 후 유효성 검사 통과된 이미지만 S3 업로드 구현

### DIFF
--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -23,7 +23,8 @@
         "react-slick": "^0.30.2",
         "redux-persist": "^6.0.0",
         "slick-carousel": "^1.8.1",
-        "universal-cookie": "^7.2.0"
+        "universal-cookie": "^7.2.0",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^1.9.0",
@@ -4821,6 +4822,19 @@
       },
       "peerDependencies": {
         "storybook": "^8.2.9"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -18301,10 +18315,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -26,7 +26,8 @@
     "react-slick": "^0.30.2",
     "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
-    "universal-cookie": "^7.2.0"
+    "universal-cookie": "^7.2.0",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.9.0",

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -2,6 +2,8 @@
 
 import '../../../../styles/mypage.css';
 
+import { useRef, useState } from 'react';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import axios from 'axios';
@@ -10,7 +12,7 @@ import kakao from '../../../../../public/image/kakao.png';
 import naver from '../../../../../public/image/naver.png';
 import profile from '../../../../../public/image/profile.jpg';
 import { useDaumPostcodePopup } from 'react-daum-postcode';
-import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 export default function Info() {
   const loginType = 'email'; // naver / email / kakao
@@ -32,6 +34,7 @@ export default function Info() {
     detail: userInfo.detail,
   });
   const [isPhoneAuth, setIsPhoneAuth] = useState(false); // 휴대폰 인증 클릭 여부
+  const imageRef = useRef(null);
   const open = useDaumPostcodePopup();
 
   const handlePhoneAuth = () => {
@@ -116,6 +119,58 @@ export default function Info() {
     setModifyType('');
   };
 
+  // 이미지 불러오기
+  const hanldeImage = async (e) => {
+    if (!e.target.value) return;
+    const image = e.target.files[0];
+    const validMimeTypes = ['image/png', 'image/jpeg']; // PNG, JPG, JPEG MIME 타입
+    const maxSizeMB = 10; // 10MB
+
+    if (!validMimeTypes.includes(image.type)) {
+      alert('프로필 이미지는 png, jpg/jpeg 파일만 가능합니다.');
+      return;
+    }
+    if (image.size > maxSizeMB * 1024 * 1024) {
+      alert('프로필 이미지는 10MB 이하의 파일만 가능합니다.');
+      return;
+    }
+
+    const imageName = uuidv4() + image.name; // 파일 이름 중복되지 않기 위함
+
+    try {
+      let response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/image`,
+        { fileName: imageName }
+      );
+      const uploadUrl = response.data.uploadUrl;
+
+      try {
+        response = await axios.put(uploadUrl, image, {
+          headers: {
+            'Content-Type': image.type,
+          },
+        });
+
+        const imageUrl = `https://dutchiepay-image.s3.amazonaws.com/${imageName}`;
+        console.log(imageUrl);
+      } catch (error) {
+        // 에러 처리
+      }
+    } catch (error) {
+      // 에러 처리
+    } finally {
+      e.target.value = ''; // 같은 이미지 연속으로 업로드 가능하도록 값을 비움
+    }
+  };
+
+  // 버튼 클릭 시 input 호출
+  const handleUploadClick = (e) => {
+    if (!imageRef.current) {
+      return;
+    }
+    imageRef.current.click();
+  };
+
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[680px]">
       <h1 className="text-[32px] font-bold">회원 정보</h1>
@@ -137,9 +192,18 @@ export default function Info() {
               />
               {modifyType === '프로필이미지' && (
                 <div className="flex flex-col gap-[4px]">
-                  <button className="border rounded-lg text-sm px-[16px] py-[4px]">
+                  <button
+                    className="border rounded-lg text-sm px-[16px] py-[4px]"
+                    onClick={handleUploadClick}
+                  >
                     프로필 변경
                   </button>
+                  <input
+                    ref={imageRef}
+                    type="file"
+                    className="hidden"
+                    onChange={hanldeImage}
+                  />
                   <button className="border rounded-lg text-sm px-[16px] py-[4px]">
                     프로필 삭제
                   </button>


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) feat/image-upload

## 변경 사항
1. 이미지 업로드 button 클릭 시 input[type=file]이 실행되도록 함
2. 파일 업로드 시 jpg/jpeg, png 확장자를 가진 파일 여부를 체크해 그 외 파일 확장자는 return
3. 확장자 검사를 통과한 파일이 10MB를 넘어갈 경우에 return
4. 2/3번 유효성 검사가 통과된 후 uuid를 이용해 파일 이름이 중복되지 않도록 저장할 파일 이름 설정
5. 이미지 업로드 API 호출을 통해 S3에 업로드할 수 있는 presignedURL을 반환받음.
6. 해당 URL을 통해 S3 버킷에 이미지 업로드
7. 업로드된 이미지 URL imageURL에 저장 -> 현재 회원정보 수정 코드가 수정 중이므로 수정정보에 저장하지 않고 별도 변수에 저장. 확인을 위해 console에 URL 출력되도록 구현.

## 테스트 결과
![image](https://github.com/user-attachments/assets/fce2a433-d6c4-46c7-8aca-eabe2ef64450)
[업로드된 이미지, URL 참고](https://dutchiepay-image.s3.amazonaws.com/f12650bb-7e5b-46ea-bf14-804528bcef7f184784283_1991282151035642_8346224865736594101_n.jpg)

## ETC
이미지  업로드 관련 코드를 추후 컴포넌트로 분리를 생각 중입니다. 현재 /info 페이지를 같이 작업 중이기 때문에 충돌을 고려해 컴포넌트를 분리하지 않고 push 했습니다.
