### PR TITLE
[feat, fix] 최근 로그인 방식 표시 및 컴포넌트 분리

### DIFF
--- a/dutchiepay/src/app/(routes)/login/page.jsx
+++ b/dutchiepay/src/app/(routes)/login/page.jsx
@@ -6,13 +6,12 @@ import '@/styles/globals.css';
 import Cookies from 'universal-cookie';
 import Image from 'next/image';
 import Link from 'next/link';
+import SocialLogin from '@/app/_components/_user/SocialLogin';
 import axios from 'axios';
 import eyeClosed from '../../../../public/image/eyeClosed.svg';
 import eyeOpen from '../../../../public/image/eyeOpen.svg';
-import kakao from '../../../../public/image/kakao.png';
 import { login } from '@/redux/slice/loginSlice';
 import logo from '../../../../public/image/logo.jpg';
-import naver from '../../../../public/image/naver.png';
 import { useDispatch } from 'react-redux';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
@@ -23,7 +22,6 @@ export default function Login() {
   const dispatch = useDispatch();
   const cookies = new Cookies();
   const [isVisible, setIsVisible] = useState(false);
-  const [loginType, setLoginType] = useState(''); // email/kakao/naver
   const [isRemeberMe, setIsRememberMe] = useState(false); // 자동로그인 체크 여부
 
   const {
@@ -169,52 +167,7 @@ export default function Login() {
             </div>
           </form>
 
-          <section>
-            <h2 className="user-login-sns__title">
-              &nbsp;SNS 계정으로 로그인&nbsp;
-            </h2>
-            <div className="flex mt-[24px] gap-[60px] items-center justify-center">
-              <div className="relative">
-                <Image
-                  className="w-[60px] h-[60px] cursor-pointer"
-                  src={naver}
-                  alt="naver"
-                />
-                {loginType === 'naver' && (
-                  <div className="user-last__login user-last__login--naver">
-                    <div
-                      className="absolute w-[50px] h-[50px] top-[0px] left-[30%] bg-white z-[-1]"
-                      aria-hidden="true"
-                    >
-                      {/* 말풍선꼬리 */}
-                    </div>
-                    <strong>마지막</strong>으로
-                    <br />
-                    로그인한 방식
-                  </div>
-                )}
-              </div>
-              <div className="relative">
-                <Image
-                  className="w-[60px] h-[60px] cursor-pointer"
-                  src={kakao}
-                  alt="kakao"
-                />
-                {loginType === 'kakao' && (
-                  <div className="user-last__login user-last__login--kakao">
-                    <div
-                      className="absolute w-[50px] h-[50px] top-[0px] left-[30%] bg-white z-[-1]"
-                      aria-hidden="true"
-                    >
-                      {/* 말풍선꼬리 */}
-                    </div>
-                    <strong>마지막</strong>으로
-                    <br /> 로그인한 방식
-                  </div>
-                )}
-              </div>
-            </div>
-          </section>
+          <SocialLogin />
         </section>
       </div>
     </section>

--- a/dutchiepay/src/app/(routes)/login/page.jsx
+++ b/dutchiepay/src/app/(routes)/login/page.jsx
@@ -64,9 +64,9 @@ export default function Login() {
         access: response.data.access,
       };
 
+      localStorage.setItem('loginType', userInfo.loginType);
       dispatch(
         login({
-          loginType: userInfo.loginType,
           user: userInfo.user,
           access: userInfo.access,
         })

--- a/dutchiepay/src/app/_components/_user/LastLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/LastLogin.jsx
@@ -1,0 +1,34 @@
+import '@/styles/globals.css';
+import '@/styles/user.css';
+
+import { useEffect, useState } from 'react';
+
+export default function LastLogin({ type }) {
+  const [loginType, setLoginType] = useState(''); // email/kakao/naver
+
+  useEffect(() => {
+    const storedLoginType = localStorage.getItem('loginType');
+    setLoginType(storedLoginType || '');
+  }, []);
+
+  return (
+    <>
+      {loginType === type && (
+        <div
+          className="user-last__login user-last__login--naver"
+          onClick={() => console.log(loginType)}
+        >
+          <div
+            className="absolute w-[50px] h-[50px] top-[0px] left-[30%] bg-white z-[-1]"
+            aria-hidden={!loginType === type}
+          >
+            {/* 말풍선꼬리 */}
+          </div>
+          <strong>마지막</strong>으로
+          <br />
+          로그인한 방식
+        </div>
+      )}
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_user/SignUpSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/SignUpSubmit.jsx
@@ -10,9 +10,11 @@ import PhoneAuth from './PhoneAuth';
 import Policy from './Policy';
 import axios from 'axios';
 import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function SignUpSubmit() {
+  const router = useRouter();
   const [address, setAddress] = useState('');
   const [phoneCode, setPhoneCode] = useState('');
   const [isAuthError, setIsAuthError] = useState(false);
@@ -64,6 +66,7 @@ export default function SignUpSubmit() {
         payload
       );
       console.log('회원가입 성공:', response.data);
+      router.push('/');
     } catch (error) {
       console.error('회원가입 실패:', error);
     }

--- a/dutchiepay/src/app/_components/_user/SocialLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialLogin.jsx
@@ -1,0 +1,35 @@
+import '@/styles/globals.css';
+import '@/styles/user.css';
+
+import { useEffect, useState } from 'react';
+
+import Image from 'next/image';
+import LastLogin from './LastLogin';
+import kakao from '../../../../public/image/kakao.png';
+import naver from '../../../../public/image/naver.png';
+
+export default function SocialLogin() {
+  return (
+    <section>
+      <h2 className="user-login-sns__title">&nbsp;SNS 계정으로 로그인&nbsp;</h2>
+      <div className="flex mt-[24px] gap-[60px] items-center justify-center">
+        <button className="relative">
+          <Image
+            className="w-[60px] h-[60px] cursor-pointer"
+            src={naver}
+            alt="naver"
+          />
+          <LastLogin type={'naver'} />
+        </button>
+        <button className="relative">
+          <Image
+            className="w-[60px] h-[60px] cursor-pointer"
+            src={kakao}
+            alt="kakao"
+          />
+          <LastLogin type={'kakao'} />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/dutchiepay/src/redux/slice/loginSlice.js
+++ b/dutchiepay/src/redux/slice/loginSlice.js
@@ -3,7 +3,6 @@ import { createSlice } from '@reduxjs/toolkit';
 // 초기 상태 정의
 const initialState = {
   isLoggedIn: false,
-  loginType: null,
   user: {
     userId: null,
     nickname: null,
@@ -21,14 +20,12 @@ const loginSlice = createSlice({
   reducers: {
     login(state, action) {
       state.isLoggedIn = true;
-      state.loginType = action.payload.loginType;
       state.user = action.payload.user;
       state.access = action.payload.access;
     },
 
     logout(state) {
       state.isLoggedIn = false;
-      state.loginType = null;
       state.user = {
         userId: null,
         nickname: null,


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) feat/Last-login -> main

## 변경 사항
1. 기존 login 완료 시, redux(session)에 저장되던 loginType을 localStorage에 저장
2. /login 페이지 렌더링 시, localStorage로부터 loginType을 불러와 소셜로그인일 경우 해당하는 소셜 버튼 하단에 표시
3. 코드 중복을 줄이기 위해 최근 로그인 표시는 컴포넌트로 분리하여 type 값을 통해 표시
4. 소셜 로그인 컴포넌트 분리
5. 회원가입 성공 시, 해당 페이지에 그대로 남아있지 않고 메인으로 이동하도록 라우팅
6. 최근 로그인 표시 div의 aria-hidden 값이 loginType에 맞게 변경되도록 수정

## 테스트 결과
※ 현재 소셜 로그인 구현이 안 되어 로그인 시 localStorage에 "kakao"가 무조건 저장되도록 코드를 수정한 뒤 테스트 (push된 코드는 실제값으로 저장됩니다)
![스크린샷 2024-09-25 164715](https://github.com/user-attachments/assets/a112ba95-85c4-4c75-8569-e88df415eb6c)


## ETC
세분화된 로그인 컴포넌트 분리를 고민했으나... 모든 내용이 로그인과 연관되어 있고, form 안에 일부 요소가 로그인 submit과 관련없으나 UI 상 form 안에 위치하여 별도 분리가 어려울 것으로 판단해 진행하지 않았습니다. (모든 요소를 분리한다면 가능은 하지만 현재 목적과는 맞지 않은 것 같아 진행하지 않았습니다.)
