### PR TITLE
[feat] refresh token 존재 시, relogin API 호출

### DIFF
--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -30,7 +30,7 @@ export default function Header() {
 
   useEffect(async () => {
     const refresh = cookies.get('refresh');
-    if (refresh) {
+    if (refresh && !isLoggedIn) {
       try {
         const response = await axios.post(
           `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`,
@@ -59,6 +59,8 @@ export default function Header() {
         );
       } catch (error) {
         // 에러처리 refresh token 만료 메시지가 반환될 경우, 로그아웃 처리
+        alert('로그아웃 유지시간이 만료되어 자동으로 로그아웃되었습니다.');
+        handleLogout();
       }
     }
   }, []);


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/relogin

## 변경 사항
1. header가 처음 렌더링 될 때 cookie에 refresh가 존재할 경우, relogin API 호출

## 테스트 결과
현재 해당 API는 백엔드에서 merge가 되지 않아 테스트는 생략합니다.
![image](https://github.com/user-attachments/assets/6fefecc2-aa7e-4ae0-abcb-2210fe008866)

## ETC
refresh 만료 오류 문구 반환 시 로그아웃 처리 구현이 필요합니다. 현재 오류 메시지 관련 내용이 명세서에 없어 추후 추가되는대로 구현 예정입니다.