### PR TITLE
[feat]reissue,로그아웃,닉네임중복검사 API호출, 위치정보 error시 default지역으로 설정 및 alert 띄우기

### DIFF
--- a/dutchiepay/src/app/(modals)/change-number/page.jsx
+++ b/dutchiepay/src/app/(modals)/change-number/page.jsx
@@ -42,7 +42,7 @@ export default function ChangeNumber() {
 
   const onSubmit = async (formData) => {
     try {
-      const response = await axios.patch(
+      await axios.patch(
         `${process.env.NEXT_PUBLIC_BASE_URL}/profile/phone`,
         { phone: formData.phone },
         {
@@ -52,7 +52,7 @@ export default function ChangeNumber() {
         }
       );
       dispatch(setPhone({ phone: formData.phone }));
-      console.log(response);
+
       window.close();
       // 핸드폰 번호를 formData.phone으로 바꾸는 로직 추가
     } catch (error) {

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -20,6 +20,7 @@ import profile from '../../../../../public/image/profile.jpg';
 import { useDaumPostcodePopup } from 'react-daum-postcode';
 import { v4 as uuidv4 } from 'uuid';
 import { useDispatch, useSelector } from 'react-redux';
+
 export default function Info() {
   const [loginType, setLoginType] = useState(''); // email/kakao/naver
   const user = useSelector((state) => state.user.user);
@@ -28,6 +29,7 @@ export default function Info() {
   const profileImage = useSelector((state) => state.login.user.profileImage);
   const accessToken = useSelector((state) => state.login.access);
   const dispatch = useDispatch();
+
   console.log(user);
 
   const [modifyType, setModifyType] = useState(''); // 수정 중인 영역 ''일 경우 아무 것도 수정 중이지 않은 상태

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -2,12 +2,7 @@
 
 import '../../../../styles/mypage.css';
 
-import {
-  setLocation,
-  setNickname,
-  setProfileImage,
-} from '@/redux/slice/loginSlice';
-import { useDispatch, useSelector } from 'react-redux';
+import { setUserInfoChange } from '@/redux/slice/loginSlice';
 import { useEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
@@ -101,7 +96,7 @@ export default function Info() {
   const handleGetCurrentLocation = async () => {
     // 정말 재설정 할 것인지 물어보는 alert 추가
     const location = await getLocation();
-    dispatch(setLocation({ location: location }));
+    dispatch(setUserInfoChange({ location: location }));
   };
   const handleModifyComplete = async () => {
     switch (modifyType) {
@@ -123,7 +118,7 @@ export default function Info() {
             console.log(response);
 
             dispatch(
-              setProfileImage({ profileImage: modifyInfo.profileImage })
+              setUserInfoChange({ profileImage: modifyInfo.profileImage })
             );
             console.log(response);
           } catch (error) {
@@ -150,7 +145,7 @@ export default function Info() {
                 },
               }
             );
-            dispatch(setNickname({ nickname: modifyInfo.nickname }));
+            dispatch(setUserInfoChange({ nickname: modifyInfo.nickname }));
           } catch (error) {
             console.log(error);
           }

--- a/dutchiepay/src/app/_components/_layout/Sidebar.jsx
+++ b/dutchiepay/src/app/_components/_layout/Sidebar.jsx
@@ -18,18 +18,27 @@ import { useEffect } from 'react';
 import axios from 'axios';
 import { setUser } from '@/redux/slice/userSlice';
 import { useRouter } from 'next/navigation';
+import Cookies from 'universal-cookie';
+import useReissueToken from '@/app/hooks/useReissueToken';
 
 export default function Sidebar() {
   const userInfo = useSelector((state) => state.login.user);
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const accessToken = useSelector((state) => state.login.access);
   const dispatch = useDispatch();
-  const user = useSelector((state) => state.user.user);
   const router = useRouter();
+  const cookies = new Cookies();
+  const refreshToken = cookies.get('refresh');
+  const newAccessToken = useReissueToken(refreshToken);
+  console.log(refreshToken);
+
+  console.log(newAccessToken);
+
   useEffect(() => {
     const initMypage = async () => {
       // 로그인이 안되어 있으면 메인 페이지로 리다이렉트
       if (!isLoggedIn) {
+        alert('비정상적인 접근입니다.');
         router.push('/');
         return;
       }

--- a/dutchiepay/src/app/_components/_user/GetLocation.jsx
+++ b/dutchiepay/src/app/_components/_user/GetLocation.jsx
@@ -26,7 +26,11 @@ export default function getLocation() {
           }
         },
         (error) => {
-          resolve('위치 정보를 가져오지 못 했습니다.');
+          alert(
+            '위치정보를 불러올 수 없어 기본 설정 지역으로 가입이 진행됩니다.'
+          );
+
+          resolve('서울시 중구');
         }
       );
     } else {

--- a/dutchiepay/src/app/_components/_user/NicknameInput.jsx
+++ b/dutchiepay/src/app/_components/_user/NicknameInput.jsx
@@ -2,7 +2,7 @@
 
 import '@/styles/globals.css';
 import '@/styles/user.css';
-
+import axios from 'axios';
 export default function NicknameInput({
   register,
   errors,
@@ -10,7 +10,25 @@ export default function NicknameInput({
   touchedFields,
 }) {
   const rNickname = /^[a-zA-Z0-9가-힣]{2,8}$/;
+  const checkNicknameAvailability = async (e) => {
+    const value = e.target.value;
+    console.log(value);
 
+    if (rNickname.test(value)) {
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/users`,
+          {
+            params: {
+              nickname: value,
+            },
+          }
+        );
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
   return (
     <>
       <div className="flex items-center">
@@ -38,6 +56,7 @@ export default function NicknameInput({
               value: rNickname,
               message: '올바른 닉네임 형식을 입력해주세요',
             },
+            onBlur: checkNicknameAvailability,
           })}
         />
       </div>

--- a/dutchiepay/src/app/_components/_user/NicknameInput.jsx
+++ b/dutchiepay/src/app/_components/_user/NicknameInput.jsx
@@ -24,6 +24,7 @@ export default function NicknameInput({
             },
           }
         );
+        console.log(response);
       } catch (error) {
         console.log(error);
       }

--- a/dutchiepay/src/app/hooks/useReissueToken.jsx
+++ b/dutchiepay/src/app/hooks/useReissueToken.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useDispatch, useSelector } from 'react-redux';
+import { setAccessToken } from '@/redux/slice/loginSlice';
+
+const useReissueToken = (refreshToken) => {
+  const accessToken = useSelector((state) => state.login.access);
+  const dispatch = useDispatch();
+  console.log(refreshToken);
+
+  const refreshAccessToken = async () => {
+    try {
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/users/reissue`,
+        {
+          access: accessToken,
+          refresh: refreshToken,
+        }
+      );
+      dispatch(setAccessToken(response.data.access));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  useEffect(() => {
+    if (refreshToken) {
+      refreshAccessToken();
+    }
+  }, [refreshToken]);
+
+  return null;
+};
+
+export default useReissueToken;

--- a/dutchiepay/src/redux/slice/loginSlice.js
+++ b/dutchiepay/src/redux/slice/loginSlice.js
@@ -44,10 +44,19 @@ const loginSlice = createSlice({
     setLocation(state, action) {
       state.user.location = action.payload.location;
     },
+    setAccessToken(state, action) {
+      state.access = action.payload.access;
+    },
   },
 });
 
 // 액션 및 리듀서 내보내기
-export const { login, logout, setProfileImage, setNickname, setLocation } =
-  loginSlice.actions;
+export const {
+  login,
+  logout,
+  setProfileImage,
+  setNickname,
+  setLocation,
+  setAccessToken,
+} = loginSlice.actions;
 export default loginSlice.reducer;

--- a/dutchiepay/src/redux/slice/loginSlice.js
+++ b/dutchiepay/src/redux/slice/loginSlice.js
@@ -35,15 +35,26 @@ const loginSlice = createSlice({
       };
       state.access = '';
     },
-    setProfileImage(state, action) {
-      state.user.profileImage = action.payload.profileImage;
+    setUserInfoChange(state, action) {
+      if (action.payload.profileImage) {
+        state.user.profileImage = action.payload.profileImage;
+      }
+      if (action.payload.nickname) {
+        state.user.nickname = action.payload.nickname;
+      }
+      if (action.payload.location) {
+        state.user.location = action.payload.location;
+      }
     },
-    setNickname(state, action) {
-      state.user.nickname = action.payload.nickname;
-    },
-    setLocation(state, action) {
-      state.user.location = action.payload.location;
-    },
+    // setProfileImage(state, action) {
+    //   state.user.profileImage = action.payload.profileImage;
+    // },
+    // setNickname(state, action) {
+    //   state.user.nickname = action.payload.nickname;
+    // },
+    // setLocation(state, action) {
+    //   state.user.location = action.payload.location;
+    // },
     setAccessToken(state, action) {
       state.access = action.payload.access;
     },
@@ -51,12 +62,6 @@ const loginSlice = createSlice({
 });
 
 // 액션 및 리듀서 내보내기
-export const {
-  login,
-  logout,
-  setProfileImage,
-  setNickname,
-  setLocation,
-  setAccessToken,
-} = loginSlice.actions;
+export const { login, logout, setUserInfoChange, setAccessToken } =
+  loginSlice.actions;
 export default loginSlice.reducer;


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) feat/password-change -> main

## 변경 사항
reissue,로그아웃,닉네임중복검사 API호출, 위치정보 error시 default지역으로 설정 및 alert 띄우기구현했습니다.

## 테스트 결과
### reissue API 

#### hooks폴더 생성 후 커스텀훅(useReissueToken) api호출했습니다 
* UI변경 없는것은 컴포넌트 보단 커스텀훅이 더 좋다고해서 커스텀훅으로 작성했습니다.
![image](https://github.com/user-attachments/assets/1c5eb72d-613d-49f0-9b20-e98ec05abd94)
![image](https://github.com/user-attachments/assets/c46227eb-a54e-4646-8cd7-742ca1b21f9f)
분기 처리 해야 할 것
1. refresh토큰 만료
2. 비정상적인 접근
2가지 경우 로그아웃 진행해야할듯 합니다. 확정나면 기능 구현하겠습니다.

### 닉네임 중복검사 API
![image](https://github.com/user-attachments/assets/ba159ab0-1365-4fc7-b33d-0e8b91fdc9b0)
현재 onBlur이벤트로 처리했습니다.

### 위치정보 error시 처리
![image](https://github.com/user-attachments/assets/9ffeabaa-08ab-4c5a-8b4c-94862128c36c)

## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
