### PR TITLE
[feat] 회원 비밀번호 재설정 시 현재 비밀번호 추가, 이메일,닉네임 중복검사, 전화번호 필수로 입력하게 구현

### DIFF
--- a/dutchiepay/src/app/_components/_user/EmailInput.jsx
+++ b/dutchiepay/src/app/_components/_user/EmailInput.jsx
@@ -2,17 +2,46 @@
 
 import '@/styles/globals.css';
 import '@/styles/user.css';
+import axios from 'axios';
 
 export default function EmailInput({
   register,
   errors,
   email,
   touchedFields,
+  setError,
+  clearErrors,
   isSignup = false,
+  isFind = false,
 }) {
+  console.log(isFind);
+
   const rEmail =
     /^[a-zA-Z0-9.!#$%&'*+/=?^_{|}~-]+@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$/;
-
+  const checkEmailAvailability = async (e) => {
+    const value = e.target.value;
+    if (rEmail.test(value)) {
+      try {
+        await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/users`, {
+          params: {
+            email: value,
+          },
+        });
+      } catch (error) {
+        // 400 오류가 발생하면 email에 대한 오류를 설정
+        if (error.response && error.response.status === 400) {
+          setError('email', {
+            type: 'manual',
+            message: '사용중인 이메일입니다',
+          });
+        } else {
+          console.error('이메일 체크 중 오류 발생:', error);
+        }
+      }
+    } else {
+      clearErrors('email'); // 닉네임 형식이 유효하지 않을 경우 초기화
+    }
+  };
   return (
     <div>
       <label className="user__label">이메일</label>
@@ -34,6 +63,7 @@ export default function EmailInput({
             value: rEmail,
             message: '올바른 이메일 형식을 입력해주세요',
           },
+          onBlur: !isFind ? checkEmailAvailability : undefined,
         })}
       />
       <p

--- a/dutchiepay/src/app/_components/_user/FindSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/FindSubmit.jsx
@@ -17,13 +17,14 @@ export default function FindSubmit({ tab, setIsFindEmail }) {
   const [hasPhone, setHasPhone] = useState(false); // 휴대폰 입력 여부 (회원가입 때문에 강제됨)
   const [isPhoneAuth, setIsPhoneAuth] = useState(false); // 핸드폰 인증 요청 여부
   const [isCodeMatch, setIsCodeMatch] = useState(null);
-
   const {
     register,
     handleSubmit,
     formState: { errors, isValid, touchedFields },
     reset,
     watch,
+    setError,
+    clearErrors,
   } = useForm({
     mode: 'onTouched',
     reValidateMode: 'onblur',
@@ -128,8 +129,11 @@ export default function FindSubmit({ tab, setIsFindEmail }) {
             <EmailInput
               register={register}
               errors={errors}
+              setError={setError}
+              clearErrors={clearErrors}
               email={email}
               touchedFields={touchedFields}
+              isFind={true}
             />
 
             <PhoneAuth

--- a/dutchiepay/src/app/_components/_user/NicknameInput.jsx
+++ b/dutchiepay/src/app/_components/_user/NicknameInput.jsx
@@ -3,33 +3,45 @@
 import '@/styles/globals.css';
 import '@/styles/user.css';
 import axios from 'axios';
+import { useState } from 'react';
+
 export default function NicknameInput({
   register,
   errors,
   nickname,
   touchedFields,
+  setError,
+  clearErrors,
 }) {
   const rNickname = /^[a-zA-Z0-9가-힣]{2,8}$/;
+
   const checkNicknameAvailability = async (e) => {
     const value = e.target.value;
-    console.log(value);
 
     if (rNickname.test(value)) {
       try {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/users`,
-          {
-            params: {
-              nickname: value,
-            },
-          }
-        );
-        console.log(response);
+        await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/users`, {
+          params: {
+            nickname: value,
+          },
+        });
+        clearErrors('nickname'); // 사용 가능한 닉네임이므로 오류를 클리어
       } catch (error) {
-        console.log(error);
+        // 400 오류가 발생하면 nickname에 대한 오류를 설정
+        if (error.response && error.response.status === 400) {
+          setError('nickname', {
+            type: 'manual',
+            message: '사용중인 닉네임입니다',
+          });
+        } else {
+          console.error('닉네임 체크 중 오류 발생:', error);
+        }
       }
+    } else {
+      clearErrors('nickname'); // 닉네임 형식이 유효하지 않을 경우 초기화
     }
   };
+
   return (
     <>
       <div className="flex items-center">

--- a/dutchiepay/src/app/_components/_user/PasswordInput.jsx
+++ b/dutchiepay/src/app/_components/_user/PasswordInput.jsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import eyeClosed from '../../../../public/image/eyeClosed.svg';
 import eyeOpen from '../../../../public/image/eyeOpen.svg';
+import { useSelector } from 'react-redux';
 
 export default function PasswordInput({
   register,
@@ -16,12 +17,15 @@ export default function PasswordInput({
   touchedFields,
   password,
   confirmPassword,
+  newPassword,
   isReset = false,
 }) {
+  const [isNewPasswordVisible, setIsNewPasswordVisible] = useState(false);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false); // 비밀번호 표시 여부
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false); // 비밀번호 확인 표시 여부
-
+  const accessToken = useSelector((state) => state.login.access);
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   useEffect(() => {
     if (password) {
       trigger('confirmPassword');
@@ -32,9 +36,56 @@ export default function PasswordInput({
 
   return (
     <>
+      {accessToken && isLoggedIn && (
+        <>
+          <div className="flex items-center">
+            <label className="user__label" htmlFor="password">
+              현재 비밀번호
+            </label>
+            <span className="ml-[8px] text-[12px]">
+              현재 사용중인 비밀번호를 입력해주세요
+            </span>
+          </div>
+          <div className="mb-[8px] flex relative">
+            <input
+              id="password"
+              className={`user__input-password mt-[4px] ${
+                touchedFields.password && errors.password
+                  ? 'user__input-password__invalid'
+                  : touchedFields.password && !errors.password && password
+                    ? 'user__input-password__valid'
+                    : ''
+              }`}
+              placeholder="현재 비밀번호"
+              type={isPasswordVisible ? 'text' : 'password'}
+              aria-required="true"
+              {...register('password', {
+                required: '비밀번호를 입력해주세요',
+                minLength: {
+                  value: 8,
+                  message: '8글자 이상 입력해주세요',
+                },
+                pattern: {
+                  value: rPassword,
+                  message: '올바른 비밀번호 형식을 입력해주세요',
+                },
+              })}
+            />
+            {password && (
+              <Image
+                className="absolute top-[50%] right-[24px] transform -translate-y-1/2 cursor-pointer"
+                src={isPasswordVisible ? eyeOpen : eyeClosed}
+                alt="eyes"
+                onClick={() => setIsPasswordVisible((prev) => !prev)}
+              />
+            )}
+          </div>
+        </>
+      )}
+
       <div>
         <div className="flex items-center">
-          <label className="user__label" htmlFor="password">
+          <label className="user__label" htmlFor="newPassword">
             {isReset && '새'} 비밀번호
           </label>
           <span className="ml-[8px] text-[12px]">
@@ -43,18 +94,20 @@ export default function PasswordInput({
         </div>
         <div className="mb-[8px] flex relative">
           <input
-            id="password"
+            id="newPassword"
             className={`user__input-password mt-[4px] ${
-              touchedFields.password && errors.password
+              touchedFields.newPassword && errors.newPassword
                 ? 'user__input-password__invalid'
-                : touchedFields.password && !errors.password && password
+                : touchedFields.newPassword &&
+                    !errors.newPassword &&
+                    newPassword
                   ? 'user__input-password__valid'
                   : ''
             }`}
             placeholder="비밀번호"
-            type={isPasswordVisible ? 'text' : 'password'}
+            type={isNewPasswordVisible ? 'text' : 'password'}
             aria-required="true"
-            {...register('password', {
+            {...register('newPassword', {
               required: '비밀번호를 입력해주세요',
               minLength: {
                 value: 8,
@@ -66,23 +119,23 @@ export default function PasswordInput({
               },
             })}
           />
-          {password && (
+          {newPassword && (
             <Image
               className="absolute top-[50%] right-[24px] transform -translate-y-1/2 cursor-pointer"
-              src={isPasswordVisible ? eyeOpen : eyeClosed}
+              src={isNewPasswordVisible ? eyeOpen : eyeClosed}
               alt="eyes"
-              onClick={() => setIsPasswordVisible((prev) => !prev)}
+              onClick={() => setIsNewPasswordVisible((prev) => !prev)}
             />
           )}
         </div>
         <p
-          className={`text-sm font-medium min-h-[20px] ${errors.password ? 'text-red--500' : 'text-blue--500'}`}
+          className={`text-sm font-medium min-h-[20px] ${errors.newPassword ? 'text-red--500' : 'text-blue--500'}`}
           role="alert"
-          aria-hidden={errors.password ? 'true' : 'false'}
+          aria-hidden={errors.newPassword ? 'true' : 'false'}
         >
-          {touchedFields.password && errors.password
-            ? errors.password.message
-            : touchedFields.password && !errors.password && password
+          {touchedFields.newPassword && errors.newPassword
+            ? errors.newPassword.message
+            : touchedFields.newPassword && !errors.newPassword && newPassword
               ? '사용가능한 비밀번호 입니다'
               : ''}
         </p>
@@ -113,7 +166,7 @@ export default function PasswordInput({
             type={isConfirmPasswordVisible ? 'text' : 'password'}
             {...register('confirmPassword', {
               validate: (value) =>
-                value === password || '비밀번호가 일치하지 않습니다.',
+                value === newPassword || '비밀번호가 일치하지 않습니다.',
             })}
           />
           {confirmPassword && (

--- a/dutchiepay/src/app/_components/_user/PhoneAuth.jsx
+++ b/dutchiepay/src/app/_components/_user/PhoneAuth.jsx
@@ -87,9 +87,7 @@ export default function PhoneAuth({
   return (
     <div>
       <div className="flex items-center">
-        <label className="user__label">
-          휴대폰 번호 {isSignup && '(선택)'}
-        </label>
+        <label className="user__label">휴대폰 번호</label>
         <span className="ml-[8px] text-[12px]">
           -을 제외한 전화번호를 입력해주세요
         </span>
@@ -113,9 +111,7 @@ export default function PhoneAuth({
               value: rPhone,
               message: '올바른 휴대폰 번호 형식을 입력해주세요',
             },
-            ...(!isSignup && {
-              required: '휴대폰 번호를 입력해주세요.',
-            }),
+            required: '휴대폰 번호를 입력해주세요.',
           })}
           disabled={isPhoneAuth}
         />

--- a/dutchiepay/src/app/_components/_user/ResetSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/ResetSubmit.jsx
@@ -35,25 +35,36 @@ export default function ResetSubmit({ email }) {
 
   const password = watch('password', '');
   const confirmPassword = watch('confirmPassword', '');
-
+  const newPassword = watch('newPassword', '');
   const onSubmit = async (formData) => {
     if (!isLoggedIn || !accessToken) {
       try {
         await axios.patch(
           `${process.env.NEXT_PUBLIC_BASE_URL}/users/pwd-nonuser`,
-          { email: email, password: formData.password }
+          { email: email, password: formData.newPassword }
         );
         alert('변경이 완료되었습니다.');
         router.push('/');
       } catch (error) {
-        console.error('비밀번호 재설정 중 오류 발생:', error);
-        alert('비밀번호 재설정에 실패했습니다. 다시 시도해 주세요.');
+        if (error.response && error.response.status === 400) {
+          alert('기존 비밀번호와 동일합니다.');
+        } else if (error.response && error.response.status === 401) {
+          alert('인증되지 않은 사용자입니다.');
+          router.push('/');
+        } else {
+          console.error('비밀번호 변경 중 오류 발생:', error);
+        }
       }
     } else {
       try {
+        console.log(formData);
+
         const response = await axios.patch(
           `${process.env.NEXT_PUBLIC_BASE_URL}/users/pwd-user`,
-          { password: formData.password },
+          {
+            password: formData.password,
+            newPassword: formData.newPassword,
+          },
           {
             headers: {
               Authorization: `Bearer ${accessToken}`,
@@ -62,6 +73,7 @@ export default function ResetSubmit({ email }) {
         );
 
         if (response.status === 200) {
+          alert('비밀번호 변경이 완료되었습니다.');
           await axios.post(
             `${process.env.NEXT_PUBLIC_BASE_URL}/users/logout`,
             {},
@@ -76,8 +88,14 @@ export default function ResetSubmit({ email }) {
           router.push('/');
         }
       } catch (error) {
-        console.error('비밀번호 재설정 중 오류 발생:', error);
-        alert('비밀번호 재설정에 실패했습니다. 다시 시도해 주세요.');
+        if (error.response && error.response.status === 400) {
+          alert('기존 비밀번호와 동일합니다.');
+        } else if (error.response && error.response.status === 401) {
+          alert('인증되지 않은 사용자입니다.');
+          router.push('/');
+        } else {
+          console.error('비밀번호 변경 중 오류 발생:', error);
+        }
       }
     }
   };
@@ -94,6 +112,7 @@ export default function ResetSubmit({ email }) {
         touchedFields={touchedFields}
         password={password}
         confirmPassword={confirmPassword}
+        newPassword={newPassword}
         isReset={true}
       />
 

--- a/dutchiepay/src/app/_components/_user/SignUpSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/SignUpSubmit.jsx
@@ -13,6 +13,7 @@ import axios from 'axios';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 
 export default function SignUpSubmit() {
   const router = useRouter();
@@ -20,12 +21,13 @@ export default function SignUpSubmit() {
   const [hasPhone, setHasPhone] = useState(false); // 휴대폰 입력 여부
   const [isPhoneAuth, setIsPhoneAuth] = useState(false); // 핸드폰 인증 요청 여부
   const [isCodeMatch, setIsCodeMatch] = useState(null);
-
   const {
     register,
     watch,
     handleSubmit,
     trigger,
+    setError,
+    clearErrors,
     formState: { errors, isValid, isSubmitting, touchedFields },
   } = useForm({
     mode: 'onTouched',
@@ -40,6 +42,7 @@ export default function SignUpSubmit() {
 
     const payload = {
       ...userData,
+      password: newPassword,
       location: address,
     };
     console.log(payload);
@@ -49,13 +52,14 @@ export default function SignUpSubmit() {
         payload
       );
       console.log('회원가입 성공:', response.data);
+
       router.push('/');
     } catch (error) {
       console.error('회원가입 실패:', error);
     }
   };
 
-  const password = watch('password');
+  const newPassword = watch('newPassword');
   const confirmPassword = watch('confirmPassword');
   const nickname = watch('nickname');
   const email = watch('email');
@@ -70,13 +74,15 @@ export default function SignUpSubmit() {
         errors={errors}
         email={email}
         touchedFields={touchedFields}
+        setError={setError} // setError 함수 전달
+        clearErrors={clearErrors} // clearErrors 함수 전달
         isSignup={true}
       />
       <PasswordInput
         register={register}
         trigger={trigger}
         errors={errors}
-        password={password}
+        newPassword={newPassword}
         confirmPassword={confirmPassword}
         touchedFields={touchedFields}
       />
@@ -85,6 +91,8 @@ export default function SignUpSubmit() {
         errors={errors}
         nickname={nickname}
         touchedFields={touchedFields}
+        setError={setError} // setError 함수 전달
+        clearErrors={clearErrors} // clearErrors 함수 전달
       />
       <AddressInput address={address} setAddress={setAddress} />
       <PhoneAuth


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) feat/user-system -> main

## 변경 사항
회원 비밀번호 재설정 시 현재 비밀번호 추가, 이메일,닉네임 중복검사, 전화번호 필수로 입력하게 구현했습니다.

## 테스트 결과

### 이메일,닉네임 중복검사
![중복 api](https://github.com/user-attachments/assets/ee110f60-069d-4bcf-95d6-de801873815f)

### 현재 비밀번호 인풋 추가
![현재비밀번호](https://github.com/user-attachments/assets/bb126c8b-129a-4459-b847-a0c2c2fedccd)

### 전화번호 필수로 입력 
![image](https://github.com/user-attachments/assets/469fdc4d-9bfe-40eb-a10b-7b1a5cf91145)

## ETC
1. 현재 회원가입 시 touchedFields 때문에 실시간으로 처리하는데 중복 API호출은 onBlur이라 input에서 포커스 해제시 호출해서 논리적으로 이상합니다... 다른 방법 찾아보겠습니다 !


2, 현재 비밀번호 input 유효성 검사를 어떻게 해야 할 지 모르겠습니다.. 저희 쪽에서 현재 password정보를 불러올 방법을 찾아야,, 실시간 유효성 검사가 가능할듯한데 잘 모르겠어요..
![image](https://github.com/user-attachments/assets/16f29abd-39a4-481f-bc15-9e6fb0b4811c)

3. 이메일 컴포넌트를 비밀번호 재설정(find페이지)랑 회원가입 페이지에서 동시에 사용함으로 isFind 변수를 추가해줬습니다.
![image](https://github.com/user-attachments/assets/04b14f0b-73bc-4c28-9705-8ece4c9d41d5)

