### PR TITLE
[refactor] 위치정보 중복되지 않도록 표시 방법 변경

### DIFF
--- a/dutchiepay/src/app/_components/_user/GetLocation.jsx
+++ b/dutchiepay/src/app/_components/_user/GetLocation.jsx
@@ -9,7 +9,7 @@ export default function getLocation() {
 
           try {
             const response = await axios.get(
-              `/api/map-reversegeocode/gc?coords=${longitude},${latitude}&output=json`,
+              `/api/map-reversegeocode/gc?coords=${longitude},${latitude} &output=json`,
               {
                 headers: {
                   'X-NCP-APIGW-API-KEY-ID':
@@ -20,7 +20,23 @@ export default function getLocation() {
               }
             );
 
-            resolve(response.data.results[0].region.area2.name);
+            const area1 = response.data.results[0].region.area1.name;
+            const area2 = response.data.results[0].region.area2.name;
+
+            // 걉치는 구 이름 리스트
+            const districts = ['중구', '동구', '서구', '남구', '북구'];
+
+            let location;
+            if (districts.includes(area2)) {
+              // area1이 구 이름일 경우
+              location = `${area1} ${area2}`;
+            } else {
+              // area2가 띄어쓰기 있을 경우 앞부분만 보이게 처리
+              const area2Parts = area2.split(' ');
+              location = `${area2Parts[0]}`; // 첫 번째 부분만 사용
+            }
+
+            resolve(location);
           } catch (error) {
             resolve('위치 정보를 불러오는 도중 오류가 발생했습니다.');
           }
@@ -30,7 +46,7 @@ export default function getLocation() {
             '위치정보를 불러올 수 없어 기본 설정 지역으로 가입이 진행됩니다.'
           );
 
-          resolve('서울시 중구');
+          resolve('서울특별시 중구');
         }
       );
     } else {


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) refator/geoLocation -> main

## 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

## 테스트 결과

**중구, 동구, 서구, 남구, 북구만 area1 포함 area2까지
ex) 서울특별시 중구, 인천광역시 중구

나머지는 area2 (띄어쓰기 있을 시 앞 부분만)
ex) 마포구, 부천시**

![image](https://github.com/user-attachments/assets/d53f947a-ded2-4933-99cb-801d77fe5536)


## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
