### PR TITLE
[Fix] 배송지 호출 관련 오류 해결 및 추가/수정/삭제 API 처리

### DIFF
--- a/dutchiepay/next.config.mjs
+++ b/dutchiepay/next.config.mjs
@@ -19,9 +19,7 @@ const nextConfig = {
     ];
   },
   images: {
-    domains: [
-      `https://${process.env.NEXT_PUBLIC_IMAGE_BUCKET}.s3.amazonaws.com`,
-    ],
+    domains: [`${process.env.NEXT_PUBLIC_IMAGE_BUCKET}.s3.amazonaws.com`],
   },
 };
 

--- a/dutchiepay/next.config.mjs
+++ b/dutchiepay/next.config.mjs
@@ -20,10 +20,8 @@ const nextConfig = {
   },
   images: {
     domains: [
-      'https://d2m4bskl88m9ql.cloudfront.net',
       `https://${process.env.NEXT_PUBLIC_IMAGE_BUCKET}.s3.amazonaws.com`,
     ],
-    unoptimized: true,
   },
 };
 

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -15,6 +15,7 @@ import logo from '../../../../public/image/logo.jpg';
 import { logout } from '@/redux/slice/loginSlice';
 import profile from '../../../../public/image/profile.jpg';
 import search from '../../../../public/image/search.svg';
+import { setAddresses } from '@/redux/slice/addressSlice';
 
 export default function Header() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
@@ -62,7 +63,7 @@ export default function Header() {
         handleLogout();
       }
     };
-    
+
     if (refresh && !isLoggedIn) {
       handleRelogin();
     }
@@ -80,6 +81,7 @@ export default function Header() {
 
   const handleLogout = useCallback(() => {
     dispatch(logout());
+    dispatch(setAddresses(null));
     cookies.remove('refresh', { path: '/' });
     sessionStorage.removeItem('user');
     router.push('/');

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
@@ -13,7 +13,7 @@ import { setAddresses } from '@/redux/slice/addressSlice';
 
 export default function DeliveryAddress() {
   const encryptedAddresses = useSelector((state) => state.address.addresses);
-  const [deliveryAddress, setDeliveryAddress] = useState([]);
+  const [deliveryAddress, setDeliveryAddress] = useState(null);
 
   useEffect(() => {
     const initMypage = async () => {
@@ -33,6 +33,7 @@ export default function DeliveryAddress() {
           process.env.NEXT_PUBLIC_SECRET_KEY
         ).toString();
         dispatch(setAddresses(encryptData));
+        console.log(deliveryAddress);
       } catch (error) {
         console.log(error);
       }
@@ -40,21 +41,21 @@ export default function DeliveryAddress() {
 
     if (!encryptedAddresses) initMypage();
     else {
-      /*setDeliveryAddress(
+      setDeliveryAddress(
         JSON.parse(
           CryptoJS.AES.decrypt(
             encryptedAddresses,
             process.env.NEXT_PUBLIC_SECRET_KEY
           ).toString(CryptoJS.enc.Utf8)
         )
-      );*/
+      );
     }
   }, []);
 
   return (
     <article>
       <h2 className="font-semibold text-2xl">배송지 관리</h2>
-      {deliveryAddress.length === 0 ? (
+      {!deliveryAddress || deliveryAddress.length === 0 ? (
         <div className="mt-[40px] flex flex-col justify-center items-center">
           <Image
             className="opacity-50"

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import '@/styles/mypage.css';
 import '@/styles/globals.css';
 
@@ -14,26 +16,28 @@ import { setAddresses } from '@/redux/slice/addressSlice';
 export default function DeliveryAddress() {
   const encryptedAddresses = useSelector((state) => state.address.addresses);
   const [deliveryAddress, setDeliveryAddress] = useState(null);
+  const access = useSelector((state) => state.login.access);
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     const initMypage = async () => {
       try {
-        response = await axios.get(
+        const response = await axios.get(
           `${process.env.NEXT_PUBLIC_BASE_URL}/delivery`,
           {
             headers: {
-              Authorization: `Bearer ${accessToken}`,
+              Authorization: `Bearer ${access}`,
             },
           }
         );
-
+        console.log(response.data);
         setDeliveryAddress(response.data);
         const encryptData = CryptoJS.AES.encrypt(
           JSON.stringify(response.data),
           process.env.NEXT_PUBLIC_SECRET_KEY
         ).toString();
         dispatch(setAddresses(encryptData));
-        console.log(deliveryAddress);
       } catch (error) {
         console.log(error);
       }
@@ -50,6 +54,48 @@ export default function DeliveryAddress() {
         )
       );
     }
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data) {
+        const { type, ...addressData } = event.data;
+
+        if (type === 'ADD_ADDRESS') {
+          setDeliveryAddress((prev) => {
+            const updatedAddress = [...prev, addressData];
+
+            const encryptData = CryptoJS.AES.encrypt(
+              JSON.stringify(updatedAddress),
+              process.env.NEXT_PUBLIC_SECRET_KEY
+            ).toString();
+            dispatch(setAddresses(encryptData));
+
+            return updatedAddress;
+          });
+        } else if (type === 'UPDATE_ADDRESS') {
+          setDeliveryAddress((prev) => {
+            const updatedAddress = prev.map((address) =>
+              address.id === addressData.id ? addressData : address
+            );
+
+            const encryptData = CryptoJS.AES.encrypt(
+              JSON.stringify(updatedAddress),
+              process.env.NEXT_PUBLIC_SECRET_KEY
+            ).toString();
+            dispatch(setAddresses(encryptData));
+
+            return updatedAddress;
+          });
+        }
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
   }, []);
 
   return (
@@ -78,6 +124,7 @@ export default function DeliveryAddress() {
             <DeliveryAddressItem
               key={index}
               deliveryAddress={item}
+              setDeliveryAddress={setDeliveryAddress}
               isFirst={index === 0}
             />
           ))}
@@ -86,11 +133,15 @@ export default function DeliveryAddress() {
       <button
         className="w-[150px] mt-[24px] px-[24px] py-[8px] bg-blue--500 text-white text-sm flex justify-between rounded block mx-auto"
         onClick={() => {
-          window.open(
-            '/delivery-address',
-            '주소지 추가',
-            'width=620, height=670, location=1'
-          );
+          if (!deliveryAddress || deliveryAddress.length < 5) {
+            window.open(
+              '/delivery-address',
+              '주소지 추가',
+              'width=620, height=670, location=1'
+            );
+          } else {
+            alert('최대 5개까지의 주소지를 저장할 수 있습니다.');
+          }
         }}
       >
         주소지 추가<p>+</p>

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
@@ -1,33 +1,71 @@
+'use client';
+
 import '@/styles/mypage.css';
 import '@/styles/globals.css';
 
+import { useDispatch, useSelector } from 'react-redux';
+
+import CryptoJS from 'crypto-js';
 import Link from 'next/link';
 import axios from 'axios';
-import { useSelector } from 'react-redux';
+import { setAddresses } from '@/redux/slice/addressSlice';
 
-export default function DeliveryAddressItem({ deliveryAddress, isFirst }) {
+export default function DeliveryAddressItem({
+  deliveryAddress,
+  setDeliveryAddress,
+  isFirst,
+}) {
   const access = useSelector((state) => state.login.access);
+  const dispatch = useDispatch();
 
   const handleDelete = async () => {
     if (confirm('주소지를 삭제하시겠습니까?')) {
       try {
         await axios.delete(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/profile/address`,
-          { addressId: deliveryAddress.addressId },
+          `${process.env.NEXT_PUBLIC_BASE_URL}/delivery`,
+
           {
+            data: { addressId: deliveryAddress.addressId },
             headers: {
               Authorization: `Bearer ${access}`,
             },
           }
         );
 
-        // 주소지 삭제 처리 코드 추가
+        setDeliveryAddress((prev) =>
+          prev.filter(
+            (address) => address.addressId !== deliveryAddress.addressId
+          )
+        );
+        const encryptData = CryptoJS.AES.encrypt(
+          JSON.stringify(deliveryAddress),
+          process.env.NEXT_PUBLIC_SECRET_KEY
+        ).toString();
+        dispatch(setAddresses(encryptData));
+
         alert('정상적으로 삭제되었습니다.');
       } catch (error) {
         //에러 처리
+        console.log(error);
       }
     }
   };
+
+  const handleUpdate = () => {
+    const popup = window.open(
+      `/delivery-address?addressid=${deliveryAddress.addressId}`,
+      '주소지 수정',
+      'width=620, height=670, location=1'
+    );
+
+    popup.onload = () => {
+      popup.postMessage(
+        { type: 'PASS_ADDRESS', ...deliveryAddress },
+        window.location.origin
+      );
+    };
+  };
+
   return (
     <div className={`${isFirst ? 'border-y' : 'border-b'} px-[12px] py-[8px]`}>
       <div className="flex justify-between items-center">
@@ -40,16 +78,7 @@ export default function DeliveryAddressItem({ deliveryAddress, isFirst }) {
           )}
         </div>
         <div className="flex gap-[12px] items-center text-sm text-gray--500">
-          <button
-            className="hover:underline"
-            onClick={() => {
-              window.open(
-                `/delivery-address?addressid=${deliveryAddress.addressId}`,
-                '주소지 추가',
-                'width=620, height=670, location=1'
-              );
-            }}
-          >
+          <button className="hover:underline" onClick={handleUpdate}>
             수정
           </button>
           <button className="hover:underline" onClick={handleDelete}>
@@ -63,7 +92,7 @@ export default function DeliveryAddressItem({ deliveryAddress, isFirst }) {
         <p className="text-gray--500">{deliveryAddress.phone}</p>
       </div>
       <p className="flex gap-[8px] items-center">
-        {deliveryAddress.address} <p>({deliveryAddress.zipcode})</p>
+        {deliveryAddress.address} <p>({deliveryAddress.zipCode})</p>
       </p>
       <p>{deliveryAddress.detail}</p>
     </div>

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
@@ -22,10 +22,9 @@ export default function DeliveryAddressItem({
     if (confirm('주소지를 삭제하시겠습니까?')) {
       try {
         await axios.delete(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/delivery`,
+          `${process.env.NEXT_PUBLIC_BASE_URL}/delivery?addressid${deliveryAddress.addressId}`,
 
           {
-            data: { addressId: deliveryAddress.addressId },
             headers: {
               Authorization: `Bearer ${access}`,
             },

--- a/dutchiepay/src/redux/slice/addressSlice.js
+++ b/dutchiepay/src/redux/slice/addressSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  addresses: [],
+  addresses: null,
 };
 
 const addressSlice = createSlice({
@@ -9,9 +9,7 @@ const addressSlice = createSlice({
   initialState,
   reducers: {
     setAddresses(state, action) {
-      if (Array.isArray(action.payload) && action.payload.length <= 5) {
-        state.addresses = action.payload;
-      }
+      state.addresses = action.payload;
     },
     addAddress(state, action) {
       if (state.addresses.length < 5) {

--- a/dutchiepay/src/redux/slice/addressSlice.js
+++ b/dutchiepay/src/redux/slice/addressSlice.js
@@ -11,26 +11,8 @@ const addressSlice = createSlice({
     setAddresses(state, action) {
       state.addresses = action.payload;
     },
-    addAddress(state, action) {
-      if (state.addresses.length < 5) {
-        state.addresses.push(action.payload);
-      }
-    },
-    updateAddress(state, action) {
-      const { index, address } = action.payload;
-      if (index >= 0 && index < state.addresses.length) {
-        state.addresses[index] = address;
-      }
-    },
-    removeAddress(state, action) {
-      const index = action.payload;
-      if (index >= 0 && index < state.addresses.length) {
-        state.addresses.splice(index, 1);
-      }
-    },
   },
 });
 
-export const { setAddresses, addAddress, updateAddress, removeAddress } =
-  addressSlice.actions;
+export const { setAddresses } = addressSlice.actions;
 export default addressSlice.reducer;

--- a/dutchiepay/src/redux/slice/loginSlice.js
+++ b/dutchiepay/src/redux/slice/loginSlice.js
@@ -46,15 +46,6 @@ const loginSlice = createSlice({
         state.user.location = action.payload.location;
       }
     },
-    // setProfileImage(state, action) {
-    //   state.user.profileImage = action.payload.profileImage;
-    // },
-    // setNickname(state, action) {
-    //   state.user.nickname = action.payload.nickname;
-    // },
-    // setLocation(state, action) {
-    //   state.user.location = action.payload.location;
-    // },
     setAccessToken(state, action) {
       state.access = action.payload.access;
     },


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/delivery-address

## 변경 사항
1. 배송지 관련 API 수정 사항 반영
2. 배송지 수정/삭제/추가 동작 시 address redux 값들 재암호화하여 저장
3. 배송지 호출 시 복호화 오류나지 않도록 수정
4. 로그아웃 시 redux 값 null로 수정 -> 이에 대한 오류는 하단 참고
5. 배송지 수정 시 팝업창으로 데이터 전달
6. 배송지 수정/추가 시 /info로 데이터 전달하여 처리 내용 deliveryAddress에 반영시켜 실시간으로 재렌더링
7. address redux 초기 값 ([])에서 (null)로 변경 -> 주소가 []일 때 init을 실행하도록 하였기 때문에 주소지를 설정하지 않은 사용자는 항상 재호출을 하고 있어 성능저하 발생. 초기값을 null로 변경하여 null과 []을 구분하여 재호출을 최소화
8. reducer setAddresses 제외 전부 삭제 -> redux는 데이터를 유지하기 위한 수단이고 암호화가 되어 있어 reducer로 address를 관리하려면 복호화 과정이 불필요하게 많아지기 때문에 초기 실행 시 useState에 addresses를 담아두고 해당 데이터를 set 함수를 이용해 처리하도록 변경 

## 테스트 결과
처리 시 문제 없이 동작
![image](https://github.com/user-attachments/assets/2c58d1be-ce00-48ae-afc9-22830773c79c)


## ETC
★ 현재 delete 함수에 body로 addressId를 전달하도록 API가 설계되었으나 일반적으로 delete는 body를 포함하지 않도록 설계되어 있어 axios에서도 body에 담을 시 data로 전달되지 않고 별도의 데이터로 전달되어 API 오류가 발생합니다. 이에 대한 처리로 data에 addressId를 담아 전달해 해결하였으나 일반적인 API 설계와 다르고 코드 자체도 다른 axios와 차이가 나 백엔드에 쿼리로 변경 요청했습니다. 추후 반영 시에는 쿼리로 수정할 예정이나 현재는 동작할 수 있도록 data에 담아 전달하는 것으로 두었습니다.

★ 로그아웃 시 redux 값이 null로 초기화되지 않고 새로운 데이터로 덮어쓰여지는 오류가 존재합니다. 해당 오류는 /info 페이지에서 로그아웃을 시도했기 때문에 로그아웃 시 자동으로 redux 값을 초기화하는 과정에서 해당 값이 null이 되어 init 함수가 실행되어 null 처리된 주소가 새로운 response로 덮어쓰여지는 상황입니다. 다른 페이지에서 로그아웃하면 문제없으나 해당 부분은 조건을 추가하여 해결해야 합니다. router 이후 null로 초기화하도록 순서를 변경하기에는 비동기적으로 일어나는 코드들이라 불가능합니다. 로그아웃 후 일정 시간 지난 뒤 삭제하는 방법으로는 해결이 가능할 듯 하나 좋은 해결법은 아닌 것 같아 일단 구현하지 않았습니다. 추후 방법을 고안해 수정하겠습니다. 
