### PR TITLE
[fix] 소셜 로그인/회원가입 성공 시 데이터 복호화 및 로그인 처리

### DIFF
--- a/dutchiepay/src/app/_components/_user/SocialSignup.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialSignup.jsx
@@ -29,24 +29,34 @@ export default function SocialSignup() {
     const handleMessage = (event) => {
       const allowedOrigins = [process.env.NEXT_PUBLIC_BASE_URL];
 
-      if (allowedOrigins.includes(event.origin)) {
+      if (
+        allowedOrigins.includes(event.origin) &&
+        event.data.type === 'OAUTH_LOGIN'
+      ) {
+        const decrypted = JSON.parse(
+          CryptoJS.AES.decrypt(
+            event.data.encrypted,
+            process.env.NEXT_PUBLIC_SECRET_KEY
+          ).toString(CryptoJS.enc.Utf8)
+        );
+
         const userInfo = {
-          userId: event.data.userId,
-          nickname: event.data.nickname,
-          profileImage: event.data.profileImg,
-          location: event.data.location,
-          isCertified: event.data.isCertified,
+          userId: decrypted.userId,
+          nickname: decrypted.nickname,
+          profileImage: decrypted.profileImg,
+          location: decrypted.location,
+          isCertified: decrypted.isCertified,
         };
 
-        localStorage.setItem('loginType', event.data.loginType || 'email');
+        localStorage.setItem('loginType', decrypted.loginType || 'email');
         dispatch(
           login({
             user: userInfo,
-            access: event.data.access,
+            access: decrypted.access,
           })
         );
 
-        cookies.set('refresh', event.data.refresh, { path: '/' });
+        cookies.set('refresh', decrypted.refresh, { path: '/' });
 
         router.push('/');
         console.log(userInfo);


### PR DESCRIPTION
…그인 처리

# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/oauth-decryption

## 변경 사항
1. 기존 소셜로그인 과정 중 response를 복호화 하는 과정을 추가했습니다.
2. 복호화 하기 위한 데이터를 수신하는 과정에서 소셜로그인과 관계없는 message를 수신해 복호화를 하는 오류가 있어 소셜 로그인을 확인할 수 있도록 type을 전달받는 로직으로 수정되어 event.data.type이 "OAUTH_LOGIN"일 경우에만 해당 데이터를 복호화하도록 수정했습니다.

## 테스트 결과
현재 해당 API가 배포되지 않아 테스트는 생략하였습니다.

## ETC
message를 전달하는 과정에서 아직 제대로 전달되는지 체크되지 못했을 뿐더러 복호화가 제대로 이루어지는지는 체크하지 못했습니다. 클라이언트 내에 복호화는 제대로 동작하나 서버-클라이언트 복호화는 소셜로그인 뿐이라 해당 부분에서도 수정사항이 있을 수 있습니다. 테스트로 인해 테스트 없이 배포되었습니다. 추후 오류 발견 시 수정하겠습니다.
