### PR TITLE
[Fix] 배송지 추가/수정/삭제 시 API 재호출 및 수정 페이지 데이터 소멸 오류 해결

### DIFF
--- a/dutchiepay/src/app/_components/_commerce/Orderer.jsx
+++ b/dutchiepay/src/app/_components/_commerce/Orderer.jsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 export default function Orderer() {
   const [isSelfMessage, setIsSelfMessage] = useState(false); // 배송 메시지 직접 입력 여부
   const [addressInfo, setAddressInfo] = useState({
-    zipcode: '',
+    zipCode: '',
     address: '',
     detail: '',
   });
@@ -22,8 +22,8 @@ export default function Orderer() {
       onComplete: (data) => {
         setAddressInfo((prevState) => ({
           ...prevState,
-          zipcode: data.zonecode,
-          address: data.jibunAddress,
+          zipCode: data.zonecode,
+          address: data.roadAddress,
         }));
       },
       width: 500,
@@ -63,7 +63,7 @@ export default function Orderer() {
                 <div className="flex items-center gap-[8px]">
                   <input
                     className="w-[70px] border rounded-lg px-[8px] py-[6px] text-sm outline-none"
-                    value={addressInfo.zipcode}
+                    value={addressInfo.zipCode}
                     placeholder="우편번호"
                   />
                   <button

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -2,6 +2,7 @@
 
 import '../../../styles/header.css';
 
+import { login, logout } from '@/redux/slice/loginSlice';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { usePathname, useRouter } from 'next/navigation';
@@ -12,7 +13,6 @@ import Link from 'next/link';
 import axios from 'axios';
 import chat from '../../../../public/image/chat.svg';
 import logo from '../../../../public/image/logo.jpg';
-import { logout } from '@/redux/slice/loginSlice';
 import profile from '../../../../public/image/profile.jpg';
 import search from '../../../../public/image/search.svg';
 import { setAddresses } from '@/redux/slice/addressSlice';
@@ -20,7 +20,7 @@ import { setAddresses } from '@/redux/slice/addressSlice';
 export default function Header() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const user = useSelector((state) => state.login.user);
-  const accessToken = useSelector((state) => state.login.access);
+  let accessToken = useSelector((state) => state.login.access);
   const dispatch = useDispatch();
   const router = useRouter();
   const cookies = new Cookies();
@@ -58,10 +58,12 @@ export default function Header() {
             access: userInfo.access,
           })
         );
+        accessToken = userInfo.access;
       } catch (error) {
         // 에러처리 refresh token 만료 메시지가 반환될 경우, 로그아웃 처리
+        console.log(error);
         alert('로그아웃 유지시간이 만료되어 자동으로 로그아웃되었습니다.');
-        handleLogout();
+        //handleLogout();
       }
     };
 

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -84,7 +84,7 @@ export default function Header() {
 
   const handleLogout = useCallback(async () => {
     try {
-      await axios.post(
+      /*await axios.post(
         `${process.env.NEXT_PUBLIC_BASE_URL}/users/logout`,
         {},
         {
@@ -92,7 +92,7 @@ export default function Header() {
             Authorization: `Bearer ${accessToken}`,
           },
         }
-      );
+      );*/
 
       dispatch(logout());
       cookies.remove('refresh', { path: '/' });

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
@@ -22,7 +22,7 @@ export default function DeliveryAddress() {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const handleDelivery = async () => {
+    const fetchDelivery = async () => {
       try {
         const response = await axios.get(
           `${process.env.NEXT_PUBLIC_BASE_URL}/delivery`,
@@ -44,7 +44,7 @@ export default function DeliveryAddress() {
       }
     };
 
-    if (!encryptedAddresses || isChanged) handleDelivery();
+    if (!encryptedAddresses || isChanged) fetchDelivery();
     else {
       setDeliveryAddress(
         JSON.parse(

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
@@ -3,20 +3,16 @@
 import '@/styles/mypage.css';
 import '@/styles/globals.css';
 
-import { useDispatch, useSelector } from 'react-redux';
-
-import CryptoJS from 'crypto-js';
 import Link from 'next/link';
 import axios from 'axios';
-import { setAddresses } from '@/redux/slice/addressSlice';
+import { useSelector } from 'react-redux';
 
 export default function DeliveryAddressItem({
   deliveryAddress,
-  setDeliveryAddress,
+  setIsChanged,
   isFirst,
 }) {
   const access = useSelector((state) => state.login.access);
-  const dispatch = useDispatch();
 
   const handleDelete = async () => {
     if (confirm('주소지를 삭제하시겠습니까?')) {
@@ -31,38 +27,13 @@ export default function DeliveryAddressItem({
           }
         );
 
-        setDeliveryAddress((prev) =>
-          prev.filter(
-            (address) => address.addressId !== deliveryAddress.addressId
-          )
-        );
-        const encryptData = CryptoJS.AES.encrypt(
-          JSON.stringify(deliveryAddress),
-          process.env.NEXT_PUBLIC_SECRET_KEY
-        ).toString();
-        dispatch(setAddresses(encryptData));
-
+        setIsChanged(true);
         alert('정상적으로 삭제되었습니다.');
       } catch (error) {
         //에러 처리
         console.log(error);
       }
     }
-  };
-
-  const handleUpdate = () => {
-    const popup = window.open(
-      `/delivery-address?addressid=${deliveryAddress.addressId}`,
-      '주소지 수정',
-      'width=620, height=670, location=1'
-    );
-
-    popup.onload = () => {
-      popup.postMessage(
-        { type: 'PASS_ADDRESS', ...deliveryAddress },
-        window.location.origin
-      );
-    };
   };
 
   return (
@@ -77,7 +48,16 @@ export default function DeliveryAddressItem({
           )}
         </div>
         <div className="flex gap-[12px] items-center text-sm text-gray--500">
-          <button className="hover:underline" onClick={handleUpdate}>
+          <button
+            className="hover:underline"
+            onClick={() => {
+              window.open(
+                `/delivery-address?addressid=${deliveryAddress.addressId}`,
+                '주소지 수정',
+                'width=620, height=670, location=1'
+              );
+            }}
+          >
             수정
           </button>
           <button className="hover:underline" onClick={handleDelete}>

--- a/dutchiepay/src/app/_components/_user/EmailInput.jsx
+++ b/dutchiepay/src/app/_components/_user/EmailInput.jsx
@@ -2,6 +2,7 @@
 
 import '@/styles/globals.css';
 import '@/styles/user.css';
+
 import axios from 'axios';
 
 export default function EmailInput({
@@ -14,8 +15,6 @@ export default function EmailInput({
   isSignup = false,
   isFind = false,
 }) {
-  console.log(isFind);
-
   const rEmail =
     /^[a-zA-Z0-9.!#$%&'*+/=?^_{|}~-]+@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$/;
   const checkEmailAvailability = async (e) => {

--- a/dutchiepay/src/app/_components/_user/SocialLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialLogin.jsx
@@ -34,12 +34,16 @@ export default function SocialLogin() {
         allowedOrigins.includes(event.origin) &&
         event.data.type === 'OAUTH_LOGIN'
       ) {
+        console.log(event.data);
+        console.log(event.data.encrypted);
         const decrypted = JSON.parse(
           CryptoJS.AES.decrypt(
             event.data.encrypted,
             process.env.NEXT_PUBLIC_SECRET_KEY
           ).toString(CryptoJS.enc.Utf8)
         );
+
+        console.log(decrypted);
 
         const userInfo = {
           userId: decrypted.userId,


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/delivery-address -> main 

## 변경 사항
1. 배송지 입력 시 지번주소가 아닌 도로명 주소로 받아오도록 수정 -> order 페이지의 우편번호 찾기 또한 수정
2. 배송지 추가/수정/삭제 시 해당 값을 클라이언트에서 직접 처리하지 않고 API를 재호출하도록 변경 -> 이중 처리 작업하지 않도록 변경
3. 배송지 수정 페이지 새로고침 시 데이터 소멸되는 오류 해결 -> 기존 데이터는 postMessageAPI를 이용해 수정 팝업 open 시 데이터를 전달하는 방식으로 구현했었습니다. 새로고침 이후 데이터를 유지할 수 없기 때문에 해당 방법 대신 redux에 저장되어 있는 값을 복호화하여 가져오도록 수정했습니다.

## 테스트 결과
API 호출 시 문제 없이 API 호출 진행 됨. 삭제는 현재 API 미구현으로 체크해보지 못했으나 같은 방법으로 구현했으므로 문제 없을 것으로 예상
![image](https://github.com/user-attachments/assets/c951b3be-65a9-4d9e-bb60-23675cd7b464)
배송지 수정 시 데이터 새로고침 이후에도 유지 확인
![image](https://github.com/user-attachments/assets/941859f2-d358-46ab-9003-d2597f2980fc)
이전 테스트에서 불러와지지 않던 아래 주소
![image](https://github.com/user-attachments/assets/6a08782f-aa81-4978-af64-443caf36bb88)
도로명 주소로 문제없이 불러와짐 (도로명/지번 어떤 걸 선택해도 도로명으로 들어오도록 함)
![image](https://github.com/user-attachments/assets/b30aa0f6-025c-49e4-8ef2-ba58228b8dc9)

## ETC
API 재호출을 시키기 위한 trigger가 필요해 isChaged 변수를 새로 두었습니다. 팝업창에서 axios가 호출되므로 set 함수를 전달할 수 없어 postMessageAPI를 데이터 전달 용도가 아닌 isChanged를 변화시키는 수단으로 변경했습니다. 삭제는 팝업이 아닌 컴포넌트에서 진행되므로 컴포넌트로 set 함수를 전달하여  @변경시켜주었습니다.
![image](https://github.com/user-attachments/assets/5459cce7-5a93-4fed-9980-57ecb59e67d4)
해당 값이 true가 될 때 API 호출 시켜주었습니다. 이에 따라 초기화로만 사용되지 않아 fetchDelivery로 변경해 용도를 조금 더 명확히 해주었습니다. 
