### PR TITLE
[fix] 마이페이지에서 로그아웃 시 addresses가 null이 되지 않는 오류 수정

### DIFF
--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -21,6 +21,7 @@ export default function Header() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const user = useSelector((state) => state.login.user);
   let accessToken = useSelector((state) => state.login.access);
+  const addresses = useSelector((state) => state.address.addresses);
   const dispatch = useDispatch();
   const router = useRouter();
   const cookies = new Cookies();
@@ -84,7 +85,7 @@ export default function Header() {
 
   const handleLogout = useCallback(async () => {
     try {
-      /*await axios.post(
+      await axios.post(
         `${process.env.NEXT_PUBLIC_BASE_URL}/users/logout`,
         {},
         {
@@ -92,17 +93,22 @@ export default function Header() {
             Authorization: `Bearer ${accessToken}`,
           },
         }
-      );*/
+      );
 
       dispatch(logout());
       cookies.remove('refresh', { path: '/' });
       sessionStorage.removeItem('user');
       router.push('/');
-      dispatch(setAddresses(null));
     } catch (error) {
       console.error('로그아웃 중 오류 발생:', error);
     }
   }, [dispatch]);
+
+  useEffect(() => {
+    if (pathname === '/' && !isLoggedIn && addresses) {
+      dispatch(setAddresses(null));
+    }
+  }, [isLoggedIn, pathname, addresses, dispatch]);
 
   const handleKeyDown = useCallback(
     (e) => {

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddress.jsx
@@ -18,7 +18,6 @@ export default function DeliveryAddress() {
   const [deliveryAddress, setDeliveryAddress] = useState(null);
   const [isChanged, setIsChanged] = useState(false);
   const access = useSelector((state) => state.login.access);
-  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -44,8 +43,9 @@ export default function DeliveryAddress() {
       }
     };
 
-    if (!encryptedAddresses || isChanged) fetchDelivery();
-    else {
+    if (!encryptedAddresses || isChanged) {
+      fetchDelivery();
+    } else {
       setDeliveryAddress(
         JSON.parse(
           CryptoJS.AES.decrypt(
@@ -62,7 +62,8 @@ export default function DeliveryAddress() {
       if (event.origin !== window.location.origin) return;
       if (
         event.data &&
-        (event.data.type === 'ADD_ADDRESS' || 'UPDATE_ADDRESS')
+        (event.data.type === 'ADD_ADDRESS' ||
+          event.data.type === 'UPDATE_ADDRESS')
       ) {
         setIsChanged(true);
       }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/mypage-logout -> main 

## 변경 사항
1. /info 페이지 렌더링 시마다 /delivery 호출되는 오류 수정
/info 페이지에서 배송지 추가/수정이 아닌 메시지를 수신 받을 때에도 isChaged를 true로 변경하고 있어 잘못 작성된 조건식을 수정했습니다.
2. 마이페이지 로그아웃 시 addresses가 null이 되지 않는 오류 수정

## 테스트 결과
![스크린샷 2024-10-08 181434](https://github.com/user-attachments/assets/a7b05f53-7473-4529-819c-468ed9ea5385)
마이페이지 로그아웃 시도 -> null
![스크린샷 2024-10-08 181440](https://github.com/user-attachments/assets/f8c1c723-c6dd-4e91-b32d-409798417431)


## ETC
마이페이지에서 로그아웃 시 fetchDelivery가 addresses가 null이 됨과 동시에 재호출되어 null 처리 이후 새롭게 호출된 값으로 덮어쓰기 되고 있는 오류가 존재했습니다. 해당 오류  해결을 위해서 addresses가 null이 되기 위해서는 pathname이 "/"이 되었을 때 진행되어야 했습니다. 이에 따라 pathname이 "/"이고 로그인 상태가 아니면서 addresses에 값이 존재할 때는 null로 변경 시켜주었습니다. 
