### PR TITLE
[chore] image domains deprecated 관련 수정

### DIFF
--- a/dutchiepay/next.config.mjs
+++ b/dutchiepay/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const IMAGE_BUCKET = process.env.NEXT_PUBLIC_IMAGE_BUCKET;
+
 const nextConfig = {
   async rewrites() {
     return [
@@ -19,7 +21,13 @@ const nextConfig = {
     ];
   },
   images: {
-    domains: [`${process.env.NEXT_PUBLIC_IMAGE_BUCKET}.s3.amazonaws.com`],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: `${IMAGE_BUCKET}.s3.amazonaws.com`,
+        pathname: '/**',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인
- [x] 설정

## 반영 브랜치
fix/image-domains-deprecated -> main

## 변경 사항
1. The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead. 해당 오류로 인해 remotePatterns 형식으로 변경
2. hostname에 환경변수가 들어갈 수 없다고 해 환경변수를 따로 빼주었습니다.

## 테스트 결과
![image](https://github.com/user-attachments/assets/74165f16-9922-4d84-9b53-01b1080148ab)

## ETC

