### PR TITLE
[fix] 소셜 로그인 복호화 오류 해결

### DIFF
--- a/dutchiepay/src/app/_components/_user/SocialLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialLogin.jsx
@@ -58,7 +58,7 @@ export default function SocialLogin() {
           nickname: extracted[2],
           profileImage: extracted[3] === 'null' ? null : extracted[3],
           location: extracted[4],
-          isCertified: Boolean(extracted[7]),
+          isCertified: extracted[7] === 'ture' ? true : false,
         };
 
         localStorage.setItem('loginType', extracted[1] || 'email');

--- a/dutchiepay/src/app/_components/_user/SocialLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialLogin.jsx
@@ -34,30 +34,42 @@ export default function SocialLogin() {
         allowedOrigins.includes(event.origin) &&
         event.data.type === 'OAUTH_LOGIN'
       ) {
-        const decrypted = JSON.parse(
-          CryptoJS.AES.decrypt(
-            event.data.encrypted,
-            process.env.NEXT_PUBLIC_SECRET_KEY
-          ).toString(CryptoJS.enc.Utf8)
-        );
+        const encryptedData = CryptoJS.enc.Base64.parse(event.data.encrypted);
+        const key = CryptoJS.enc.Utf8.parse(process.env.NEXT_PUBLIC_SECRET_KEY);
+        const decrypted = CryptoJS.AES.decrypt(
+          { ciphertext: encryptedData },
+          key,
+          {
+            mode: CryptoJS.mode.ECB,
+            padding: CryptoJS.pad.Pkcs7,
+          }
+        ).toString(CryptoJS.enc.Utf8);
+
+        const extracted = decrypted
+          .trim()
+          .split(',')
+          .map((item) => {
+            const value = item.split(':')[1].trim();
+            return value.replace(/(^"|"$)/g, '');
+          });
 
         const userInfo = {
-          userId: decrypted.userId,
-          nickname: decrypted.nickname,
-          profileImage: decrypted.profileImg,
-          location: decrypted.location,
-          isCertified: decrypted.isCertified,
+          userId: Number(extracted[0]),
+          nickname: extracted[2],
+          profileImage: extracted[3] === 'null' ? null : extracted[3],
+          location: extracted[4],
+          isCertified: Boolean(extracted[7]),
         };
 
-        localStorage.setItem('loginType', decrypted.loginType || 'email');
+        localStorage.setItem('loginType', extracted[1] || 'email');
         dispatch(
           login({
             user: userInfo,
-            access: decrypted.access,
+            access: extracted[5],
           })
         );
 
-        cookies.set('refresh', decrypted.refresh, { path: '/' });
+        cookies.set('refresh', extracted[6], { path: '/' });
 
         router.push('/');
         console.log(userInfo);

--- a/dutchiepay/src/app/_components/_user/SocialSignup.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialSignup.jsx
@@ -33,30 +33,42 @@ export default function SocialSignup() {
         allowedOrigins.includes(event.origin) &&
         event.data.type === 'OAUTH_LOGIN'
       ) {
-        const decrypted = JSON.parse(
-          CryptoJS.AES.decrypt(
-            event.data.encrypted,
-            process.env.NEXT_PUBLIC_SECRET_KEY
-          ).toString(CryptoJS.enc.Utf8)
-        );
+        const encryptedData = CryptoJS.enc.Base64.parse(event.data.encrypted);
+        const key = CryptoJS.enc.Utf8.parse(process.env.NEXT_PUBLIC_SECRET_KEY);
+        const decrypted = CryptoJS.AES.decrypt(
+          { ciphertext: encryptedData },
+          key,
+          {
+            mode: CryptoJS.mode.ECB,
+            padding: CryptoJS.pad.Pkcs7,
+          }
+        ).toString(CryptoJS.enc.Utf8);
+
+        const extracted = decrypted
+          .trim()
+          .split(',')
+          .map((item) => {
+            const value = item.split(':')[1].trim();
+            return value.replace(/(^"|"$)/g, '');
+          });
 
         const userInfo = {
-          userId: decrypted.userId,
-          nickname: decrypted.nickname,
-          profileImage: decrypted.profileImg,
-          location: decrypted.location,
-          isCertified: decrypted.isCertified,
+          userId: Number(extracted[0]),
+          nickname: extracted[2],
+          profileImage: extracted[3] === 'null' ? null : extracted[3],
+          location: extracted[4],
+          isCertified: Boolean(extracted[7]),
         };
 
-        localStorage.setItem('loginType', decrypted.loginType || 'email');
+        localStorage.setItem('loginType', extracted[1] || 'email');
         dispatch(
           login({
             user: userInfo,
-            access: decrypted.access,
+            access: extracted[5],
           })
         );
 
-        cookies.set('refresh', decrypted.refresh, { path: '/' });
+        cookies.set('refresh', extracted[6], { path: '/' });
 
         router.push('/');
         console.log(userInfo);

--- a/dutchiepay/src/app/_components/_user/SocialSignup.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialSignup.jsx
@@ -57,7 +57,7 @@ export default function SocialSignup() {
           nickname: extracted[2],
           profileImage: extracted[3] === 'null' ? null : extracted[3],
           location: extracted[4],
-          isCertified: Boolean(extracted[7]),
+          isCertified: extracted[7] === 'ture' ? true : false,
         };
 
         localStorage.setItem('loginType', extracted[1] || 'email');


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/oauth-decryption -> main

## 변경 사항
1. 소셜 로그인 시 복호화 오류가 발생하지 않도록 복호화 방식을 수정했습니다.
2. JSON 형식으로 전달하는 과정 중 오류가 있어 해당 데이터를 문자열 형태로 전달받도록 수정했습니다.
3. 문자열 형태로 전달된 값을 처리하여 필요한 값이 저장되어 있는 배열로 변환했습니다. 해당 값을 로그인 정보에 저장시켜주었습니다. 이때 형변환이 필요한 userId, isCertified는 형변환을 진행했고, profileImage가 "null"인 경우 null로 저장되도록 해주었습니다.
![image](https://github.com/user-attachments/assets/41faf329-6f62-4349-8238-06111a0148cb)
![image](https://github.com/user-attachments/assets/fb15efe4-5a89-408a-b82f-9d232cfd026d)



## 테스트 결과
![image](https://github.com/user-attachments/assets/027df156-9f73-4410-a933-285e7ab59d2b)

## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
