### PR TITLE
[Feat] 휴대폰 미인증 회원 접근 제한

### DIFF
--- a/dutchiepay/next.config.mjs
+++ b/dutchiepay/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const IMAGE_BUCKET = process.env.NEXT_PUBLIC_IMAGE_BUCKET;
+
 const nextConfig = {
   async rewrites() {
     return [
@@ -19,7 +21,13 @@ const nextConfig = {
     ];
   },
   images: {
-    domains: [`${process.env.NEXT_PUBLIC_IMAGE_BUCKET}.s3.amazonaws.com`],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: `${IMAGE_BUCKET}.s3.amazonaws.com`,
+        pathname: '/**',
+      },
+    ],
   },
 };
 

--- a/dutchiepay/src/app/(routes)/extra-info/page.jsx
+++ b/dutchiepay/src/app/(routes)/extra-info/page.jsx
@@ -17,12 +17,12 @@ export default function ExtraInfo() {
   const isCertified = useSelector((state) => state.login.user.isCertified);
   const router = useRouter();
 
-  /*useEffect(() => {
+  useEffect(() => {
     if ((isCertified && isLoggedIn) || !isLoggedIn) {
       alert('잘못된 접근 방식');
       router.push('/');
     }
-  }, []);*/
+  }, []);
 
   return (
     <section className="w-full flex flex-col items-center justify-center min-h-[735px]">

--- a/dutchiepay/src/app/(routes)/extra-info/page.jsx
+++ b/dutchiepay/src/app/(routes)/extra-info/page.jsx
@@ -5,45 +5,34 @@ import '@/styles/user.css';
 
 import { useEffect, useState } from 'react';
 
+import AddInfoSubmit from '@/app/_components/_user/AddInfoSubmit';
 import Image from 'next/image';
 import Link from 'next/link';
-import AddInfoSubmit from '@/app/_components/_user/AddInfoSubmit';
 import logo from '../../../../public/image/logo.jpg';
 import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
-export default function AddInfo() {
+export default function ExtraInfo() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const isCertified = useSelector((state) => state.login.user.isCertified);
   const router = useRouter();
 
-  useEffect(() => {
+  /*useEffect(() => {
     if ((isCertified && isLoggedIn) || !isLoggedIn) {
       alert('잘못된 접근 방식');
       router.push('/');
     }
-  }, []);
+  }, []);*/
 
   return (
-    <section className="w-full flex flex-col items-center justify-center min-h-[890px]">
-      <h1>
-        <Link href="/">
-          <Image
-            className="w-[200px] h-[120px] mb-[16px]"
-            src={logo}
-            alt="더취페이"
-            width={200}
-            height={120}
-          />
-        </Link>
-      </h1>
+    <section className="w-full flex flex-col items-center justify-center min-h-[735px]">
       <section className="flex flex-col w-[500px]">
-        <h2 className="text-2xl font-bold">추가 정보 입력</h2>
-        <p>
-          가입하신 계정의<strong>지역</strong>과 <strong>휴대폰 번호</strong>
-          로 인증해주셔야
+        <h1 className="text-4xl font-bold">추가 정보 입력</h1>
+        <p className="mt-[12px] mb-[24px]">
+          가입하신 계정의 <strong>지역</strong>과 <strong>휴대폰 번호</strong>
+          로 인증해주시면
           <br />
-          더취페이를 <strong>이용</strong> 하실 수 있습니다.
+          정상적으로 더취페이를 <strong>이용</strong> 하실 수 있습니다.
         </p>
         <AddInfoSubmit />
       </section>

--- a/dutchiepay/src/app/layoutClient.js
+++ b/dutchiepay/src/app/layoutClient.js
@@ -11,6 +11,7 @@ import Footer from './_components/_layout/Footer';
 import Header from './_components/_layout/Header';
 import { PersistGate } from 'redux-persist/integration/react';
 import UpDownButton from './_components/_layout/UpDownButton';
+import { useEffect } from 'react';
 
 export default function RootLayoutClient({ children }) {
   return (
@@ -35,22 +36,17 @@ function LayoutWrapper({ children }) {
     /\/(ask|report|cancel|refund|review|coupon|change-number|delivery-address)/
   );
   const rhideFloating = pathname.match(
-    /\/(login|find|signup|ask|report|cancel|refund|review|coupon|change-number|delivery-address)/
+    /\/(login|find|signup|ask|report|cancel|refund|review|coupon|change-number|delivery-address|extra-info)/
   );
 
-  if (isLoggedIn && !isCertified) {
-    // 사용자가 extra-info 페이지로 리다이렉션
-    if (!pathname.startsWith('/extra-info')) {
-      router.push('/extra-info');
+  useEffect(() => {
+    if (isLoggedIn && !isCertified) {
+      // 사용자가 extra-info 페이지로 리다이렉션
+      if (!pathname.startsWith('/extra-info')) {
+        router.push('/extra-info');
+      }
     }
-    return (
-      <>
-        <Header />
-        <main className={`layout mt-[155px]`}>{children}</main>
-        <Footer />
-      </>
-    );
-  }
+  }, [isLoggedIn, isCertified, pathname, router]);
 
   return (
     <>

--- a/dutchiepay/src/app/layoutClient.js
+++ b/dutchiepay/src/app/layoutClient.js
@@ -4,7 +4,7 @@ import '../styles/globals.css';
 
 import { Provider, useSelector } from 'react-redux';
 import { persistor, store } from '@/redux/store';
-import { usePathname, useRouter } from 'next/navigation';
+import { redirect, usePathname } from 'next/navigation';
 
 import Floating from './_components/_layout/Floating';
 import Footer from './_components/_layout/Footer';
@@ -25,7 +25,6 @@ export default function RootLayoutClient({ children }) {
 
 function LayoutWrapper({ children }) {
   const pathname = usePathname();
-  const router = useRouter();
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const isCertified = useSelector((state) => state.login.user.isCertified);
 
@@ -43,7 +42,7 @@ function LayoutWrapper({ children }) {
     if (isLoggedIn && !isCertified) {
       // 사용자가 extra-info 페이지로 리다이렉션
       if (!pathname.startsWith('/extra-info')) {
-        router.push('/extra-info');
+        redirect('/extra-info');
       }
     }
   }, [isLoggedIn, isCertified, pathname, router]);


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/access-control-by-certification -> main

## 변경 사항
1. layoutClient.js에서 useSelector로 isLoggedIn과 isCertified를 가져오는 부분이 Provider 안에서 호출되도록 하기 위해 LayoutWrapper라는 하위 컴포넌트를 추가해주었습니다.
2. isLoggedIn이 true이고 isCertified가 false인 회원에 한해 /extra-info 이외의 pathname을 가진 곳에서는 /extra-info로 이동되게 해 접근을 차단해주었습니다. 
3. addInfo 폴더를 대문자가 URL에 포함되어 있고 추가 정보라는 의미와 다소 다르다고 생각되어 extra-info로 변경했습니다.
4. up/down 버튼과 floating 버튼이 extra-info에서는 표시되지 않고 header가 존재하기 때문에 로고가 불필요하다고 생각되어 로고를 삭제하고 추가 정보 페이지임을 나타내는 title을 조금 더 크게 표시해주었습니다.

## 테스트 결과
현재 merge되지 않은 소셜 로그인 내용이 포함되어 해당 코드만으로는 정상적으로 동작하지 않습니다.
oauth-decryprtion branch에서 해당 코드를 추가하여 수정했을 때 문제 없이 동작했음을 확인했습니다. 로그아웃 시, 해당 조건들에서 벗어나고 main으로 자동으로 이동되기 때문에 흐름에 문제없이 동작하고 있습니다. 

## ETC
처음 router.push로 구현했으나 redirect가 조금 더 명확한 의미를 가질 수 있을 것 같고, redirecct는 히스토리를 남기지 않는다고 해서 불필요한 히스토리가 생기지 않기 위해 redirect로 변경했습니다. 페이지가 이동이 된 후에 redirect가 진행되기 때문에 어쩔 수 없이 깜빡이는 현상이 가끔 발생할 수 있습니다.
