### PR TITLE
[feat] 기본 배송지를 일반 배송지로 변경 시 처리 및 기본 배송지 변경 버튼 추가

### DIFF
--- a/dutchiepay/src/app/(modals)/delivery-address/page.jsx
+++ b/dutchiepay/src/app/(modals)/delivery-address/page.jsx
@@ -70,13 +70,10 @@ export default function Address() {
           }
         );
 
-        const message = {
-          type: 'UPDATE_ADDRESS',
-          addressId: addressId,
-          ...formData,
-        };
-
-        window.opener.postMessage(message, window.location.origin);
+        window.opener.postMessage(
+          { type: 'UPDATE_ADDRESS' },
+          window.location.origin
+        );
 
         alert('주소지가 수정되었습니다.');
         closeWindow();
@@ -86,7 +83,7 @@ export default function Address() {
       }
     } else {
       try {
-        const response = await axios.post(
+        await axios.post(
           `${process.env.NEXT_PUBLIC_BASE_URL}/delivery`,
           { ...formData },
           {
@@ -96,13 +93,10 @@ export default function Address() {
           }
         );
 
-        const message = {
-          type: 'ADD_ADDRESS',
-          addressId: response.data.addressId,
-          ...formData,
-        };
-
-        window.opener.postMessage(message, window.location.origin);
+        window.opener.postMessage(
+          { type: 'ADD_ADDRESS' },
+          window.location.origin
+        );
 
         alert('배송지가 추가되었습니다.');
         closeWindow();

--- a/dutchiepay/src/app/(modals)/delivery-address/page.jsx
+++ b/dutchiepay/src/app/(modals)/delivery-address/page.jsx
@@ -18,6 +18,7 @@ export default function Address() {
   const addressId = searchParams.get('addressid'); // 해당 값이 존재하면 수정, 존재하지 않으면 추가
   const access = useSelector((state) => state.login.access);
   const encryptedAddresses = useSelector((state) => state.address.addresses);
+  const [isDefaultAddress, setIsDefaultAddress] = useState(false); // 수정 요청 주소지가 기본 배송지였을 경우 true
 
   const {
     register,
@@ -52,6 +53,8 @@ export default function Address() {
       setValue('address', findAddress.address);
       setValue('detail', findAddress.detail);
       setValue('isDefault', findAddress.isDefault);
+
+      setIsDefaultAddress(findAddress.isDefault);
     };
 
     if (addressId) fetchAddress();
@@ -60,6 +63,16 @@ export default function Address() {
   const onSubmit = async (formData) => {
     if (addressId) {
       try {
+        if (isDefaultAddress && !formData.isDefault) {
+          if (
+            confirm(
+              '최소 1개의 기본 배송지를 가져야 합니다.\n확인 시 기본 배송지로 설정된 채로 수정됩니다.'
+            )
+          ) {
+            formData.isDefault = true;
+          } else return;
+        }
+
         await axios.patch(
           `${process.env.NEXT_PUBLIC_BASE_URL}/delivery`,
           { addressId: addressId, ...formData },
@@ -78,7 +91,6 @@ export default function Address() {
         alert('주소지가 수정되었습니다.');
         closeWindow();
       } catch (error) {
-        // 에러 처리
         console.log(error);
       }
     } else {

--- a/dutchiepay/src/app/(routes)/extra-info/page.jsx
+++ b/dutchiepay/src/app/(routes)/extra-info/page.jsx
@@ -5,14 +5,14 @@ import '@/styles/user.css';
 
 import { useEffect, useState } from 'react';
 
+import AddInfoSubmit from '@/app/_components/_user/AddInfoSubmit';
 import Image from 'next/image';
 import Link from 'next/link';
-import AddInfoSubmit from '@/app/_components/_user/AddInfoSubmit';
 import logo from '../../../../public/image/logo.jpg';
 import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
-export default function AddInfo() {
+export default function ExtraInfo() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const isCertified = useSelector((state) => state.login.user.isCertified);
   const router = useRouter();

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -45,7 +45,7 @@ export default function Header() {
           user: {
             userId: response.data.userId,
             nickname: response.data.nickname,
-            profileImage: response.data.profileImage,
+            profileImage: response.data.profileImg,
             location: response.data.location,
             isCertified: response.data.isCertified,
           },
@@ -102,7 +102,7 @@ export default function Header() {
     } catch (error) {
       console.error('로그아웃 중 오류 발생:', error);
     }
-  }, [dispatch]);
+  }, [dispatch, accessToken, router]);
 
   useEffect(() => {
     if (pathname === '/' && !isLoggedIn && addresses) {

--- a/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
+++ b/dutchiepay/src/app/_components/_mypage/DeliveryAddressItem.jsx
@@ -3,7 +3,6 @@
 import '@/styles/mypage.css';
 import '@/styles/globals.css';
 
-import Link from 'next/link';
 import axios from 'axios';
 import { useSelector } from 'react-redux';
 
@@ -18,7 +17,7 @@ export default function DeliveryAddressItem({
     if (confirm('주소지를 삭제하시겠습니까?')) {
       try {
         await axios.delete(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/delivery?addressid${deliveryAddress.addressId}`,
+          `${process.env.NEXT_PUBLIC_BASE_URL}/delivery?addressid=${deliveryAddress.addressId}`,
 
           {
             headers: {

--- a/dutchiepay/src/app/layoutClient.js
+++ b/dutchiepay/src/app/layoutClient.js
@@ -4,7 +4,7 @@ import '../styles/globals.css';
 
 import { Provider, useSelector } from 'react-redux';
 import { persistor, store } from '@/redux/store';
-import { usePathname, useRouter } from 'next/navigation';
+import { redirect, usePathname, useRouter } from 'next/navigation';
 
 import Floating from './_components/_layout/Floating';
 import Footer from './_components/_layout/Footer';
@@ -43,7 +43,7 @@ function LayoutWrapper({ children }) {
     if (isLoggedIn && !isCertified) {
       // 사용자가 extra-info 페이지로 리다이렉션
       if (!pathname.startsWith('/extra-info')) {
-        router.push('/extra-info');
+        redirect('/extra-info');
       }
     }
   }, [isLoggedIn, isCertified, pathname, router]);

--- a/dutchiepay/src/app/layoutClient.js
+++ b/dutchiepay/src/app/layoutClient.js
@@ -2,18 +2,32 @@
 
 import '../styles/globals.css';
 
+import { Provider, useSelector } from 'react-redux';
 import { persistor, store } from '@/redux/store';
+import { usePathname, useRouter } from 'next/navigation';
 
 import Floating from './_components/_layout/Floating';
 import Footer from './_components/_layout/Footer';
 import Header from './_components/_layout/Header';
 import { PersistGate } from 'redux-persist/integration/react';
-import { Provider } from 'react-redux';
 import UpDownButton from './_components/_layout/UpDownButton';
-import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
 
 export default function RootLayoutClient({ children }) {
+  return (
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <LayoutWrapper>{children}</LayoutWrapper>
+      </PersistGate>
+    </Provider>
+  );
+}
+
+function LayoutWrapper({ children }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const isCertified = useSelector((state) => state.login.user.isCertified);
 
   const rhideHeader = pathname.match(
     /\/(login|reset|find|signup|ask|report|cancel|refund|review|coupon|change-number|delivery-address)/
@@ -22,21 +36,27 @@ export default function RootLayoutClient({ children }) {
     /\/(ask|report|cancel|refund|review|coupon|change-number|delivery-address)/
   );
   const rhideFloating = pathname.match(
-    /\/(login|find|signup|ask|report|cancel|refund|review|coupon|change-number|delivery-address)/
+    /\/(login|find|signup|ask|report|cancel|refund|review|coupon|change-number|delivery-address|extra-info)/
   );
 
-  return (
-    <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        {!rhideHeader && <Header />}
+  useEffect(() => {
+    if (isLoggedIn && !isCertified) {
+      // 사용자가 extra-info 페이지로 리다이렉션
+      if (!pathname.startsWith('/extra-info')) {
+        router.push('/extra-info');
+      }
+    }
+  }, [isLoggedIn, isCertified, pathname, router]);
 
-        <main className={`layout ${!rhideHeader ? 'mt-[155px]' : ''}`}>
-          {children}
-          {!rhideFloating && <Floating />}
-          {!rhideFloating && <UpDownButton />}
-        </main>
-        {!rhideFooter && <Footer />}
-      </PersistGate>
-    </Provider>
+  return (
+    <>
+      {!rhideHeader && <Header />}
+      <main className={`layout ${!rhideHeader ? 'mt-[155px]' : ''}`}>
+        {children}
+        {!rhideFloating && <Floating />}
+        {!rhideFloating && <UpDownButton />}
+      </main>
+      {!rhideFooter && <Footer />}
+    </>
   );
 }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/default-address -> main

## 변경 사항
1. 배송지 삭제 API URL 오타 수정 -> 현재 배송지 삭제 API가 수정 중이라 동작되지 않을 수 있습니다.
2. 기본 배송지를 일반 배송지로 수정하는 경우, 기본 배송지 1개를 유지하기 위해 사용자에게 안내 후, isDefault를 기존값으로 전달
3. 일반 배송지를 수정 창을 이용하지 않고 버튼을 이용해 기본 배송지로 변경할 수 있도록 버튼 추가

## 테스트 결과
기본 배송지가 아닐 경우, 기본 배송지로 설정 버튼이 표시 -> confirm을 통해 변경 여부 체크 -> 해당 주소지를 isDefault를 true로 수정하는 API 호출 -> API에 의해 기존 기본 배송지는 일반 배송지로 해당 배송지는 기본 배송지로 변경
![image](https://github.com/user-attachments/assets/d881bd69-bb70-443b-a87b-1254b8b6b4b0)

기본 배송지를 일반 배송지로 변경하였을 때 confirm을 통해 수정되지 않음을 안내 -> 확인 시,  isDefault를 true로 변경해 수정 API를 호출
![image](https://github.com/user-attachments/assets/0a2e7344-82f1-40d4-87ff-4c792c0f1030)
![스크린샷 2024-10-11 201350](https://github.com/user-attachments/assets/a7f27785-7a6c-4d93-a58e-7309eb1e4862)


## ETC
기본 배송지를 일반 배송지로 수정할 수 없게 되면서 사용자에게 기본 배송지로 설정하기 위해서는 수정 팝업을 거쳐야 했습니다. 다만, isDefault만 변경되는 부분이기 때문에 같은 동작이더라도 불필요한 과정을 줄이고 사용성을 높이고자 해당 부분만 수정되는 버튼을 추가해주었습니다. 실제 동작은 동일하게 진행됩니다.