### PR TITLE
[Design] mypage UI 수정

### DIFF
--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -244,6 +244,7 @@ export default function Info() {
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[680px]">
       <h1 className="text-[32px] font-bold">회원 정보</h1>
+      <small>{nickname}님의 계정 정보를 확인하고 변경하실 수 있습니다.</small>
       <section className="mt-[40px] flex flex-col gap-[36px] mb-[24px]">
         <article className="mypage-profile">
           <div className="flex items-center">

--- a/dutchiepay/src/app/(routes)/mypage/like/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/like/page.jsx
@@ -4,15 +4,20 @@ import '@/styles/mypage.css';
 
 import Image from 'next/image';
 import Product_Like from '@/app/_components/Product';
+import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
 // 좋아요 상품 없을 때 UI도 구현해야 함
 export default function Like() {
   const [filter, setFilter] = useState('전체');
+  const nickname = useSelector((state) => state.login.user.nickname);
 
   return (
     <section className="ml-[250px] p-[30px] min-h-[750px]">
       <h1 className="text-[32px] font-bold">좋아요한 상품</h1>
+      <small>
+        {nickname}님께서 좋아요한 공동구매 상품을 확인할 수 있습니다.
+      </small>
       <ul className="flex gap-[8px] my-[16px]">
         <li>
           <button

--- a/dutchiepay/src/app/(routes)/mypage/myask/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/myask/page.jsx
@@ -1,13 +1,19 @@
-import '../../../../styles/mypage.css';
+'use client';
+
+import '@/styles/mypage.css';
 
 import Image from 'next/image';
 import MyAsks from '@/app/_components/_mypage/MyAsk';
+import { useSelector } from 'react-redux';
 
 // 문의내역 없을 때 UI도 구현해야 함
 export default function MyAsk() {
+  const nickname = useSelector((state) => state.login.user.nickname);
+
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[750px]">
       <h1 className="text-[32px] font-bold">문의내역</h1>
+      <small>{nickname}님께서 문의하신 내역들을 확인할 수 있습니다.</small>
       <section className="flex flex-col gap-[16px] mt-[16px]">
         <MyAsks />
         <MyAsks />

--- a/dutchiepay/src/app/(routes)/mypage/mycoupon/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/mycoupon/page.jsx
@@ -1,13 +1,20 @@
+'use client';
+
 import '@/styles/mypage.css';
+import '@/styles/globals.css';
 
 import Coupon_List from '@/app/_components/_mypage/Coupon_List';
+import { useSelector } from 'react-redux';
 
 // 쿠폰 없을 때 UI도 구현해야 함
 export default function MyCoupon() {
+  const nickname = useSelector((state) => state.login.user.nickname);
+
   return (
-    <section className="ml-[250px] p-[30px] min-h-[750px]">
-      <h1 className="text-[32px] font-bold mb-[16px]">사용 가능 쿠폰</h1>
-      <section className="flex flex-wrap gap-y-[20px] gap-x-[16px]">
+    <section className="ml-[250px] p-[30px] min-h-[734px]">
+      <h1 className="text-[32px] font-bold">사용 가능 쿠폰</h1>
+      <small>{nickname}님께서 사용가능한 쿠폰을 확인할 수 있습니다.</small>
+      <section className="mt-[32px] flex flex-wrap gap-y-[20px] gap-x-[16px]">
         <Coupon_List />
         <Coupon_List />
         <Coupon_List />

--- a/dutchiepay/src/app/(routes)/mypage/myorder/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/myorder/page.jsx
@@ -3,15 +3,20 @@
 import Image from 'next/image';
 import Order from '@/app/_components/_mypage/Order';
 import arrow from '../../../../../public/image/arrow.svg';
+import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
 export default function MyOrder() {
   const [filter, setFilter] = useState('전체');
+  const nickname = useSelector((state) => state.login.user.nickname);
 
   // 구매내역 없을 때 UI도 구현해야 함
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[750px]">
       <h1 className="text-[32px] font-bold">구매내역</h1>
+      <small>
+        {nickname}님께서 구매하신 공동구매 상품을 확인할 수 있습니다.
+      </small>
       <ul className="flex gap-[8px] my-[16px]">
         <li>
           <button

--- a/dutchiepay/src/app/(routes)/mypage/mypost/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/mypost/page.jsx
@@ -5,15 +5,20 @@ import '@/styles/globals.css';
 
 import Image from 'next/image';
 import Post from '@/app/_components/Post';
+import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
 // 작성 게시글 없을 때 UI도 구현해야 함
 export default function MyPost() {
   const [filter, setFilter] = useState('작성한 게시글');
+  const nickname = useSelector((state) => state.login.user.nickname);
 
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[750px]">
       <h1 className="text-[32px] font-bold">활동내역</h1>
+      <small>
+        {nickname}님이 작성하고 댓글을 남긴 게시글을 확인할 수 있습니다.
+      </small>
       <ul className="flex gap-[8px] my-[16px]">
         <li>
           <button
@@ -32,7 +37,7 @@ export default function MyPost() {
           </button>
         </li>
       </ul>
-      <section className="flex flex-wrap gap-[12px]">
+      <section className="flex flex-wrap gap-[12px] mb-[40px]">
         <Post />
         <Post />
         <Post />

--- a/dutchiepay/src/app/(routes)/mypage/myreview/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/myreview/page.jsx
@@ -1,14 +1,20 @@
+'use client';
+
 import '@/styles/mypage.css';
 import '@/styles/globals.css';
 
 import Image from 'next/image';
 import MyReviews from '@/app/_components/_mypage/MyReview';
+import { useSelector } from 'react-redux';
 
 // 리뷰내역 없을 때 UI도 구현해야 함
 export default function MyReview() {
+  const nickname = useSelector((state) => state.login.user.nickname);
+
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[750px]">
       <h1 className="text-[32px] font-bold">작성한 후기</h1>
+      <small>{nickname}님께서 작성하신 상품의 후기를 확인할 수 있습니다.</small>
       <section className="flex flex-col gap-[12px] mt-[16px]">
         <MyReviews />
         <MyReviews />

--- a/dutchiepay/src/app/_components/_layout/Sidebar.jsx
+++ b/dutchiepay/src/app/_components/_layout/Sidebar.jsx
@@ -32,7 +32,7 @@ export default function Sidebar() {
   }, []);
 
   return (
-    <aside className="w-[250px] h-[730px] bg-white border-r p-[16px] mb-[70px] flex flex-col items-center gap-[32px] fixed">
+    <aside className="w-[250px] h-[730px] bg-white border-r px-[16px] py-[40px] mb-[70px] flex flex-col items-center gap-[32px] fixed">
       <div className="flex flex-col items-center">
         <Image
           className="w-[120px] h-[120px] rounded-full border mb-[12px]"


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 디자인

## 반영 브랜치
design/mypage-ui -> main

## 변경 사항
1. 쿠폰 수와 공구 진행 수가 삭제됨에 따라 하단 여백을 조금 제거하고 page의 padding과 맞추기 위해 영역을 일부 아래로 이동
2. /mypage 내 페이지의 description이 부족하다고 생각되어 title 밑에 description을 추가했습니다.

## 테스트 결과
![image](https://github.com/user-attachments/assets/3bced021-bc70-4485-8051-c62f4a66b413)


## ETC
추가 수정 사항 : sidebar의 Link가 li의 padding으로 인해 실제 표시되는 영역보다 클릭 가능 범위가 작아 클릭이 제대로 되지 않고 있습니다. 
li의 padding을 제거하고 Link로 padding을 추가하는 방식으로 수정 예정