### PR TITLE
[Fix] mypage 관련 오류 수정

### DIFF
--- a/dutchiepay/src/app/(modals)/delivery-address/page.jsx
+++ b/dutchiepay/src/app/(modals)/delivery-address/page.jsx
@@ -60,6 +60,10 @@ export default function Address() {
     if (addressId) fetchAddress();
   }, [addressId]);
 
+  const onError = () => {
+    alert('상세주소 외에 모든 내용은 필수 값입니다.');
+  };
+
   const onSubmit = async (formData) => {
     if (addressId) {
       try {
@@ -143,7 +147,7 @@ export default function Address() {
       </h1>
       <form
         className="mt-[40px] flex flex-col gap-[8px]"
-        onSubmit={handleSubmit(onSubmit)}
+        onSubmit={handleSubmit(onSubmit, onError)}
       >
         <input
           className="address__input"

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -289,12 +289,10 @@ export default function Info() {
                   <button
                     className="border rounded-lg text-sm px-[16px] py-[4px]"
                     onClick={() => {
-                      // 기본 프로필 이미지로 변경
                       setModifyInfo((prevState) => ({
                         ...prevState,
-                        profileImage: profile.src, // 기본 프로필 이미지로 설정
+                        profileImage: null,
                       }));
-                      dispatch(setUserInfoChange({ profileImage: profile })); // Redux 상태 업데이트
                     }}
                   >
                     프로필 삭제

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -34,7 +34,6 @@ export default function Info() {
   const [modifyInfo, setModifyInfo] = useState({
     nickname: nickname,
     profileImage: profileImage,
-    location: location,
   });
   const imageRef = useRef(null);
   const rnickname = /^[a-zA-Z0-9가-힣]{2,8}$/;
@@ -124,7 +123,21 @@ export default function Info() {
   const handleGetCurrentLocation = async () => {
     if (confirm('지역을 재설정 하시겠습니까?')) {
       const location = await getLocation();
-      dispatch(setUserInfoChange({ location: location }));
+
+      try {
+        await axios.patch(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/profile/location`,
+          { location: location },
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+        dispatch(setUserInfoChange({ location: location }));
+      } catch (error) {
+        alert('오류가 발생했습니다. 다시 시도해주세요.');
+      }
     }
   };
 
@@ -317,7 +330,7 @@ export default function Info() {
             {modifyType === '닉네임' ? (
               <input
                 className="px-[8px] py-[4px] border rounded-lg outline-none"
-                value={modifyInfo.nickname || nickname}
+                value={modifyInfo.nickname || ''}
                 onChange={(e) =>
                   setModifyInfo((prevState) => ({
                     ...prevState,

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -191,7 +191,7 @@ export default function Header() {
                 src={chat}
               />
               <Image
-                className="w-[55px] h-[55px] rounded-full border ml-[18px]"
+                className="w-[55px] h-[55px] rounded-full border ml-[18px] cursor-pointer"
                 src={user?.profileImage || profile}
                 alt="profile"
                 width={55}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/mypage-info

## 변경 사항
1. header 프로필 버튼 클릭 시 cursor 효과 추가
2. 지역 변경 시 API 호출
3. 닉네임 수정 시 값이 지워지지 않는 오류 수정
4. 프로필 삭제 클릭 시 바로 반영되지 않도록 변경
5. 주소지 추가/수정 시 필수 값 입력하지 않았을 경우 alert 추가

## 테스트 결과
![image](https://github.com/user-attachments/assets/f77d5a52-1d0b-45be-b58c-7c546a1466cb)
![image](https://github.com/user-attachments/assets/39596532-ed57-49c9-a06c-46615f6a0ed7)


## ETC
프로필 삭제 시에 해당 데이터를 null로 처리해야 추후 기본 프로필로 표시할 수 있으나 현재 null로 프로필 이미지를 변경 시 오류가 있어 백엔드에 오류 사항 전달했습니다. 방법이 변경되면  수정하겠습니다.
