### PR TITLE
[feat] 휴대폰 번호 입력 시 하이픈(-) 무시

### DIFF
--- a/dutchiepay/src/app/(modals)/change-number/page.jsx
+++ b/dutchiepay/src/app/(modals)/change-number/page.jsx
@@ -3,12 +3,12 @@
 import '@/styles/user.css';
 import '@/styles/globals.css';
 
-import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 
 import PhoneAuth from '@/app/_components/_user/PhoneAuth';
 import axios from 'axios';
 import { useForm } from 'react-hook-form';
+import { useSelector } from 'react-redux';
 
 export default function ChangeNumber() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
@@ -16,12 +16,12 @@ export default function ChangeNumber() {
   const [hasPhone, setHasPhone] = useState(false); // 휴대폰 입력 여부
   const [isPhoneAuth, setIsPhoneAuth] = useState(false); // 핸드폰 인증 요청 여부
   const [isCodeMatch, setIsCodeMatch] = useState(null);
-  const dispatch = useDispatch();
 
   const {
     register,
     watch,
     handleSubmit,
+    setValue,
     formState: { errors, touchedFields },
   } = useForm({
     mode: 'onTouched',
@@ -30,12 +30,12 @@ export default function ChangeNumber() {
     shouldFocusError: true,
   });
 
-  /*useEffect(() => {
+  useEffect(() => {
     if (!isLoggedIn || !access) {
       alert('비정상적인 접속');
       closeWindow();
     }
-  }, []);*/ // 개발을 위해 비회원일 때도 페이지 접근 가능하도록 임시 비활성화
+  }, []);
 
   const onSubmit = async (formData) => {
     try {
@@ -86,6 +86,7 @@ export default function ChangeNumber() {
           watch={watch}
           errors={errors}
           touchedFields={touchedFields}
+          setValue={setValue}
           setHasPhone={setHasPhone}
           isPhoneAuth={isPhoneAuth}
           setIsPhoneAuth={setIsPhoneAuth}

--- a/dutchiepay/src/app/(modals)/delivery-address/page.jsx
+++ b/dutchiepay/src/app/(modals)/delivery-address/page.jsx
@@ -166,13 +166,17 @@ export default function Address() {
         />
         <input
           className="address__input"
-          type="number"
+          type="text"
           placeholder="전화번호"
           {...register('phone', {
             required: '전화번호를 입력해주세요,',
             pattern: {
               value: rPhone,
               message: '올바른 휴대폰 번호 형식을 입력해주세요',
+            },
+            onChange: (e) => {
+              const newValue = e.target.value.replace(/[^0-9]/g, '');
+              setValue('phone', newValue);
             },
           })}
         />

--- a/dutchiepay/src/app/_components/_commerce/Orderer.jsx
+++ b/dutchiepay/src/app/_components/_commerce/Orderer.jsx
@@ -52,7 +52,7 @@ export default function Orderer() {
             <td className="px-[16px]">
               <input
                 className="border rounded-lg px-[8px] py-[6px] text-sm outline-none"
-                placeholder="전화번호(ex) 01012345678)"
+                placeholder="전화번호(ex) 01012345678)" /* 추후 하이픈 제거 코드 추가 */
               />
             </td>
           </tr>

--- a/dutchiepay/src/app/_components/_user/FindSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/FindSubmit.jsx
@@ -27,6 +27,7 @@ export default function FindSubmit({ tab, setIsFindEmail }) {
     watch,
     setError,
     clearErrors,
+    setValue,
   } = useForm({
     mode: 'onTouched',
     reValidateMode: 'onblur',
@@ -102,6 +103,7 @@ export default function FindSubmit({ tab, setIsFindEmail }) {
               watch={watch}
               errors={errors}
               touchedFields={touchedFields}
+              setValue={setValue}
               setHasPhone={setHasPhone}
               isPhoneAuth={isPhoneAuth}
               setIsPhoneAuth={setIsPhoneAuth}
@@ -157,6 +159,7 @@ export default function FindSubmit({ tab, setIsFindEmail }) {
               watch={watch}
               errors={errors}
               touchedFields={touchedFields}
+              setValue={setValue}
               setHasPhone={setHasPhone}
               isPhoneAuth={isPhoneAuth}
               setIsPhoneAuth={setIsPhoneAuth}

--- a/dutchiepay/src/app/_components/_user/PhoneAuth.jsx
+++ b/dutchiepay/src/app/_components/_user/PhoneAuth.jsx
@@ -9,6 +9,7 @@ export default function PhoneAuth({
   watch,
   errors,
   touchedFields,
+  setValue,
   setHasPhone,
   isPhoneAuth,
   setIsPhoneAuth,
@@ -94,7 +95,7 @@ export default function PhoneAuth({
       </div>
       <div className="mt-[4px] mb-[8px] flex relative">
         <input
-          type="number"
+          type="text"
           className={`user__input mt-[4px] ${
             touchedFields.phone && errors.phone
               ? 'user__input__invalid'
@@ -107,6 +108,10 @@ export default function PhoneAuth({
           placeholder="휴대폰 번호 (ex : 01012345678)"
           maxLength={11}
           {...register('phone', {
+            onChange: (e) => {
+              const newValue = e.target.value.replace(/[^0-9]/g, '');
+              setValue('phone', newValue);
+            },
             pattern: {
               value: rPhone,
               message: '올바른 휴대폰 번호 형식을 입력해주세요',

--- a/dutchiepay/src/app/_components/_user/SignUpSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/SignUpSubmit.jsx
@@ -27,6 +27,7 @@ export default function SignUpSubmit() {
     watch,
     handleSubmit,
     trigger,
+    setValue,
     setError,
     clearErrors,
     formState: { errors, isValid, isSubmitting, touchedFields },
@@ -105,6 +106,7 @@ export default function SignUpSubmit() {
         errors={errors}
         touchedFields={touchedFields}
         isPhoneAuth={isPhoneAuth}
+        setValue={setValue}
         setIsPhoneAuth={setIsPhoneAuth}
         setHasPhone={setHasPhone}
         isCodeMatch={isCodeMatch}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/phone-hypen-remove

## 변경 사항
휴대폰 번호 입력 input에 - 입력 시 제거되도록 추가

## 테스트 결과
생략

## ETC
number만 입력되므로 type을 number형으로 구현했었지만, "-"은 number 형에서도 입력이 가능하긴 하지만, 해당 값을 제거하면 모든 문자열이 다 지워질 수 있다고 합니다. 그래서 text type으로 변경해 [0-9] 외에 값들은 제거되도록 수정했습니다.
휴대폰을 입력하는 페이지에 최대한 추가했으나 누락됐을 수 있습니다. 또한 Orderer에서는 현재 form이 구현되지 않아 추후 form 구현시 추가하도록 주석으로 표시해두었습니다.
