### PR TITLE
[refactor] 로그인 컴포넌트 분리

### DIFF
--- a/dutchiepay/src/app/(routes)/login/page.jsx
+++ b/dutchiepay/src/app/(routes)/login/page.jsx
@@ -1,9 +1,9 @@
 import '@/styles/user.css';
 import '@/styles/globals.css';
 
-import LoginSubmit from '@/app/_components/_user/LoginSubmit';
+import LoginSubmit from '@/app/_components/_user/_login/LoginSubmit';
 import Logo from '@/app/_components/Logo';
-import SocialLogin from '@/app/_components/_user/SocialLogin';
+import SocialLogin from '@/app/_components/_user/_login/SocialLogin';
 
 export default function Login() {
   return (

--- a/dutchiepay/src/app/(routes)/signup/page.jsx
+++ b/dutchiepay/src/app/(routes)/signup/page.jsx
@@ -8,14 +8,11 @@ import SocialSignup from '@/app/_components/_user/SocialSignup';
 
 export default function Signup() {
   return (
-    <section className="w-full flex flex-col items-center justify-center min-h-[880px]">
+    <section className="w-full flex flex-col items-center justify-center min-h-[880px] pt-[60px]">
       <Logo />
-      <h2 className="text-[20px] font-bold text-start w-[500px] mb-[16px]">
-        간편 회원가입
-      </h2>
+      <SocialSignup />
+      <hr className="w-[500px] my-[10px] border-t-[2px] border-gray--300" />
       <section className="w-[500px]">
-        <SocialSignup />
-        <hr className="w-[500px] my-[10px] border-t-[2px] border-gray--300" />
         <SignUpSubmit />
         <div className="flex flex-col">
           <Link

--- a/dutchiepay/src/app/_components/_user/SocialSignup.jsx
+++ b/dutchiepay/src/app/_components/_user/SocialSignup.jsx
@@ -83,23 +83,28 @@ export default function SocialSignup() {
   }, []);
 
   return (
-    <div className="flex gap-[20px] h-[70px]">
-      <button
-        className="user-signup__button bg-[#00c73c] text-white"
-        onClick={() => openPopup('naver')}
-        type="button"
-      >
-        <Image src={naver} width={40} height={40} alt="naver" />
-        <p>네이버로 시작하기</p>
-      </button>
-      <button
-        className="user-signup__button bg-[#FBDB44]"
-        onClick={() => openPopup('kakao')}
-        type="button"
-      >
-        <Image src={kakao} width={40} height={40} alt="kakao" />
-        <span>카카오로 시작하기</span>
-      </button>
-    </div>
+    <>
+      <h2 className="text-[20px] font-bold text-start w-[500px] mb-[16px]">
+        간편 회원가입
+      </h2>
+      <div className="flex gap-[20px] h-[70px]">
+        <button
+          className="user-signup__button bg-[#00c73c] text-white"
+          onClick={() => openPopup('naver')}
+          type="button"
+        >
+          <Image src={naver} width={40} height={40} alt="naver" />
+          <p>네이버로 시작하기</p>
+        </button>
+        <button
+          className="user-signup__button bg-[#FBDB44]"
+          onClick={() => openPopup('kakao')}
+          type="button"
+        >
+          <Image src={kakao} width={40} height={40} alt="kakao" />
+          <span>카카오로 시작하기</span>
+        </button>
+      </div>
+    </>
   );
 }

--- a/dutchiepay/src/app/_components/_user/_login/LastLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LastLogin.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import '@/styles/globals.css';
 import '@/styles/user.css';
 
@@ -14,10 +16,7 @@ export default function LastLogin({ type }) {
   return (
     <>
       {loginType === type && (
-        <div
-          className="user-last__login user-last__login--naver"
-          onClick={() => console.log(loginType)}
-        >
+        <div className="user-last__login user-last__login--naver">
           <div
             className="absolute w-[50px] h-[50px] top-[0px] left-[30%] bg-white z-[-1]"
             aria-hidden={!loginType === type}

--- a/dutchiepay/src/app/_components/_user/_login/LoginButton.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LoginButton.jsx
@@ -1,0 +1,17 @@
+import '@/styles/globals.css';
+import '@/styles/user.css';
+
+import Link from 'next/link';
+
+export default function LoginButton() {
+  return (
+    <div className="flex flex-col gap-[8px] mt-[12px]">
+      <button type="submit" className="user__button-blue">
+        로그인
+      </button>
+      <Link href="/signup" className="user__button-white" role="button">
+        회원가입
+      </Link>
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_components/_user/_login/LoginInput.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LoginInput.jsx
@@ -2,8 +2,8 @@ import '@/styles/user.css';
 import '@/styles/globals.css';
 
 import Image from 'next/image';
-import eyeClosed from '../../../../public/image/eyeClosed.svg';
-import eyeOpen from '../../../../public/image/eyeOpen.svg';
+import eyeClosed from '/public/image/eyeClosed.svg';
+import eyeOpen from '/public/image/eyeOpen.svg';
 import { useState } from 'react';
 
 export default function LoginInput({

--- a/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
@@ -4,8 +4,9 @@ import '@/styles/globals.css';
 import '@/styles/user.css';
 
 import Cookies from 'universal-cookie';
-import Link from 'next/link';
+import LoginButton from './LoginButton';
 import LoginInput from './LoginInput';
+import RememberMe from './RememberMe';
 import axios from 'axios';
 import { login } from '@/redux/slice/loginSlice';
 import { useDispatch } from 'react-redux';
@@ -83,31 +84,8 @@ export default function LoginSubmit() {
         isSubmitted={isSubmitted}
         isUnauthorized={isUnauthorized}
       />
-      <div className="flex flex-col gap-[8px] mt-[12px]">
-        <button type="submit" className="user__button-blue">
-          로그인
-        </button>
-        <Link href="/signup" className="user__button-white" role="button">
-          회원가입
-        </Link>
-      </div>
-
-      <div className="flex justify-between items-center mt-[8px] mb-[32px]">
-        <div className="flex items-center gap-[8px]">
-          <input
-            id="remeberMe"
-            type="checkbox"
-            className="login__checkbox"
-            onChange={(e) => setIsRememberMe(e.target.checked)}
-          />
-          <label className="text-gray--500 text-sm" htmlFor="remeberMe">
-            자동 로그인
-          </label>
-        </div>
-        <Link href="/find" className="text-sm text-gray--500 hover:text-black">
-          아이디/비밀번호 찾기
-        </Link>
-      </div>
+      <LoginButton />
+      <RememberMe setIsRememberMe={setIsRememberMe} />
     </form>
   );
 }

--- a/dutchiepay/src/app/_components/_user/_login/RememberMe.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/RememberMe.jsx
@@ -1,0 +1,28 @@
+import '@/styles/globals.css';
+import '@/styles/user.css';
+
+import Link from 'next/link';
+
+export default function RememberMe({ setIsRememberMe }) {
+  return (
+    <div className="flex justify-between items-center mt-[8px] mb-[32px]">
+      <div className="flex items-center gap-[8px]">
+        <input
+          id="remeberMe"
+          type="checkbox"
+          className="login__checkbox"
+          onChange={(e) => setIsRememberMe(e.target.checked)}
+        />
+        <label
+          className="text-gray--500 text-sm hover:text-black"
+          htmlFor="remeberMe"
+        >
+          자동 로그인
+        </label>
+      </div>
+      <Link href="/find" className="text-sm text-gray--500 hover:text-black">
+        아이디/비밀번호 찾기
+      </Link>
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_components/_user/_login/SocialButton.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/SocialButton.jsx
@@ -1,0 +1,36 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/user.css';
+
+import Image from 'next/image';
+import LastLogin from './LastLogin';
+import kakao from '/public/image/kakao.png';
+import naver from '/public/image/naver.png';
+
+export default function SocialButton({ type }) {
+  const openPopup = () => {
+    window.open(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/oauth/signup?type=${type}`,
+      `${type} 회원가입`,
+      'width=600,height=400'
+    );
+  };
+
+  const getImageSrc = () => {
+    return type === 'naver' ? naver : kakao;
+  };
+
+  return (
+    <button className="relative" onClick={() => openPopup()}>
+      <Image
+        className="cursor-pointer"
+        src={getImageSrc()}
+        alt={type}
+        width={60}
+        height={60}
+      />
+      <LastLogin type={type} />
+    </button>
+  );
+}

--- a/dutchiepay/src/app/_components/_user/_login/SocialLogin.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/SocialLogin.jsx
@@ -3,30 +3,18 @@
 import '@/styles/globals.css';
 import '@/styles/user.css';
 
-import { useEffect, useState } from 'react';
-
 import Cookies from 'universal-cookie';
 import CryptoJS from 'crypto-js';
-import Image from 'next/image';
-import LastLogin from './LastLogin';
-import kakao from '../../../../public/image/kakao.png';
+import SocialButton from './SocialButton';
 import { login } from '@/redux/slice/loginSlice';
-import naver from '../../../../public/image/naver.png';
 import { useDispatch } from 'react-redux';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
 export default function SocialLogin() {
   const router = useRouter();
   const cookies = new Cookies();
   const dispatch = useDispatch();
-
-  const openPopup = (type) => {
-    window.open(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/oauth/signup?type=${type}`,
-      `${type} 회원가입`,
-      'width=600,height=400'
-    );
-  };
 
   useEffect(() => {
     const handleMessage = (event) => {
@@ -89,22 +77,8 @@ export default function SocialLogin() {
     <section>
       <h2 className="user-login-sns__title">&nbsp;SNS 계정으로 로그인&nbsp;</h2>
       <div className="flex mt-[24px] gap-[60px] items-center justify-center">
-        <button className="relative" onClick={() => openPopup('naver')}>
-          <Image
-            className="w-[60px] h-[60px] cursor-pointer"
-            src={naver}
-            alt="naver"
-          />
-          <LastLogin type={'naver'} />
-        </button>
-        <button className="relative" onClick={() => openPopup('kakao')}>
-          <Image
-            className="w-[60px] h-[60px] cursor-pointer"
-            src={kakao}
-            alt="kakao"
-          />
-          <LastLogin type={'kakao'} />
-        </button>
+        <SocialButton type={'naver'} />
+        <SocialButton type={'kakao'} />
       </div>
     </section>
   );


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인
- [x] 리팩토링

## 반영 브랜치
refactor/split-login -> main

## 변경 사항
1. _component의 하위 폴더 _login을 생성해 로그인과 관련된 컴포넌트를 묶어두었습니다.
2. loginSubmit을 input / 자동로그인&아이디 찾기 / 로그인&회원가입으로 분리했습니다.
3. SocialLogin 재사용이 가능하도록 컴포넌트를 분리했습니다.

## 테스트 결과
기존과 동일하게 동작합니다.

## ETC
이미지 경로로 인해 폴더 정리가 어려워지는 것 같아 리팩토링 과정을 진행하면서 경로를 절대경로로 수정하려고 합니다. 추후 이미지를 import 하실 때에도 절대경로로 사용해주시면 됩니다.
