### PR TITLE
[refactor] useReissueToken 내부에서 refresh 불러오게 수정

### DIFF
--- a/dutchiepay/src/app/hooks/useReissueToken.jsx
+++ b/dutchiepay/src/app/hooks/useReissueToken.jsx
@@ -2,11 +2,12 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useDispatch, useSelector } from 'react-redux';
 import { setAccessToken } from '@/redux/slice/loginSlice';
-
-const useReissueToken = (refreshToken) => {
+import Cookies from 'universal-cookie';
+const useReissueToken = () => {
+  const cookies = new Cookies();
   const accessToken = useSelector((state) => state.login.access);
+  const refresh = cookies.get('refresh');
   const dispatch = useDispatch();
-  console.log(refreshToken);
 
   const refreshAccessToken = async () => {
     try {
@@ -14,19 +15,18 @@ const useReissueToken = (refreshToken) => {
         `${process.env.NEXT_PUBLIC_BASE_URL}/users/reissue`,
         {
           access: accessToken,
-          refresh: refreshToken,
+          refresh: refresh,
         }
       );
-      dispatch(setAccessToken(response.data.access));
+
+      dispatch(setAccessToken({ access: response.data.access }));
     } catch (error) {
-      console.log(error);
+      alert('새로운 accecc토큰 생성 중 에러가 발생했습니다.');
     }
   };
   useEffect(() => {
-    if (refreshToken) {
-      refreshAccessToken();
-    }
-  }, [refreshToken]);
+    refreshAccessToken();
+  }, []);
 
   return null;
 };

--- a/dutchiepay/src/app/hooks/useReissueToken.jsx
+++ b/dutchiepay/src/app/hooks/useReissueToken.jsx
@@ -21,7 +21,7 @@ const useReissueToken = () => {
 
       dispatch(setAccessToken({ access: response.data.access }));
     } catch (error) {
-      alert('새로운 accecc토큰 생성 중 에러가 발생했습니다.');
+      alert('오류가 발생하여 로그아웃 처리 되었습니다');
     }
   };
   useEffect(() => {


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex) refactor/reissueToken -> main

## 변경 사항
useReissueToken 호출 시 access 저장 못하는 버그 수정, 내부에서 refresh token 불러오게 수정

## 테스트 결과
![image](https://github.com/user-attachments/assets/2e86790f-c2f2-4a27-a64c-97db10040c11)
정상적으로 새로운 토큰 발급됩니다.

## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
