### PR TITLE
[Refactor] 회원정보 수정 컴포넌트 분리

### DIFF
--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -9,18 +9,17 @@ import { useEffect, useRef, useState } from 'react';
 import DeliveryAddress from '@/app/_components/_mypage/DeliveryAddress';
 import Image from 'next/image';
 import Link from 'next/link';
+import ModifyLocation from '@/app/_components/_mypage/_modify/ModifyLocation';
 import ModifyNumber from '@/app/_components/_mypage/_modify/ModifyNumber';
 import Withdraw from '@/app/_components/_mypage/Withdraw';
 import axios from 'axios';
 import getImage from '@/app/_components/GetImage';
-import getLocation from '@/app/_components/_user/GetLocation';
 import kakao from '../../../../../public/image/kakao.png';
 import naver from '../../../../../public/image/naver.png';
 import profile from '../../../../../public/image/profile.jpg';
 import { setUserInfoChange } from '@/redux/slice/loginSlice';
 
 export default function Info() {
-  const location = useSelector((state) => state.login.user.location);
   const nickname = useSelector((state) => state.login.user.nickname);
   const profileImage = useSelector((state) => state.login.user.profileImage);
   const accessToken = useSelector((state) => state.login.access);
@@ -96,27 +95,6 @@ export default function Info() {
       }
     });
     setModifyType(''); // 수정 중인 상태 초기화
-  };
-
-  const handleGetCurrentLocation = async () => {
-    if (confirm('지역을 재설정 하시겠습니까?')) {
-      const location = await getLocation();
-
-      try {
-        await axios.patch(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/profile/location`,
-          { location: location },
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          }
-        );
-        dispatch(setUserInfoChange({ location: location }));
-      } catch (error) {
-        alert('오류가 발생했습니다. 다시 시도해주세요.');
-      }
-    }
   };
 
   const handleModifyComplete = async (e) => {
@@ -305,18 +283,7 @@ export default function Info() {
             </button>
           </div>
         </article>
-        <article className="mypage-profile">
-          <div className="flex items-center">
-            <h2 className="mypage-profile__label">지역</h2>
-            <p className="mypage-profile__value">{location}</p>
-          </div>
-          <button
-            className="mypage-profile__button"
-            onClick={handleGetCurrentLocation}
-          >
-            재설정
-          </button>
-        </article>
+        <ModifyLocation />
         <ModifyNumber userInfo={userInfo} setUserInfo={setUserInfo} />
         <article className="mypage-profile">
           <div className="flex items-center">

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -3,37 +3,31 @@
 import '@/styles/globals.css';
 import '@/styles/mypage.css';
 
-import { useDispatch, useSelector } from 'react-redux';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import AccountInfo from '@/app/_components/_mypage/AccountInfo';
 import DeliveryAddress from '@/app/_components/_mypage/DeliveryAddress';
-import Image from 'next/image';
 import ModifyLocation from '@/app/_components/_mypage/_modify/ModifyLocation';
+import ModifyNickname from '@/app/_components/_mypage/_modify/ModifyNickname';
 import ModifyNumber from '@/app/_components/_mypage/_modify/ModifyNumber';
+import ModifyProfileImg from '@/app/_components/_mypage/_modify/ModifyProfileImg';
 import Withdraw from '@/app/_components/_mypage/Withdraw';
 import axios from 'axios';
-import getImage from '@/app/_components/GetImage';
-import profile from '../../../../../public/image/profile.jpg';
-import { setUserInfoChange } from '@/redux/slice/loginSlice';
+import { useSelector } from 'react-redux';
 
 export default function Info() {
   const nickname = useSelector((state) => state.login.user.nickname);
   const profileImage = useSelector((state) => state.login.user.profileImage);
   const accessToken = useSelector((state) => state.login.access);
-  const dispatch = useDispatch();
 
   const [userInfo, setUserInfo] = useState({
     email: null,
     phone: null,
   });
-  const [modifyType, setModifyType] = useState(''); // 수정 중인 영역 ''일 경우 아무 것도 수정 중이지 않은 상태
   const [modifyInfo, setModifyInfo] = useState({
     nickname: nickname,
     profileImage: profileImage,
   });
-  const imageRef = useRef(null);
-  const rnickname = /^[a-zA-Z0-9가-힣]{2,8}$/;
 
   // email/phone API 호출 및 session 저장
   useEffect(() => {
@@ -68,215 +62,16 @@ export default function Info() {
     }
   }, []);
 
-  const handleModifyType = (type) => {
-    // 수정할 타입이 현재 타입과 다를 때만 취소 함수 호출
-    if (modifyType && modifyType !== type) {
-      handleModifyCancel(); // 이전 수정 상태 취소
-    }
-    setModifyType(modifyType === type ? '' : type); // 같은 타입일 경우 취소, 다른 타입일 경우 새로 설정
-  };
-
-  // 수정 취소
-  const handleModifyCancel = () => {
-    setModifyInfo((prevModifyInfo) => {
-      switch (modifyType) {
-        case '닉네임':
-          return { ...prevModifyInfo, nickname: nickname };
-        case '프로필이미지':
-          return { ...prevModifyInfo, profileImage: profileImage };
-        default:
-          return prevModifyInfo;
-      }
-    });
-    setModifyType(''); // 수정 중인 상태 초기화
-  };
-
-  const handleModifyComplete = async (e) => {
-    e.preventDefault(); // 기본 동작 방지
-
-    switch (modifyType) {
-      case '프로필이미지':
-        try {
-          await axios.patch(
-            `${process.env.NEXT_PUBLIC_BASE_URL}/profile/image`,
-            { profileImg: modifyInfo.profileImage },
-            {
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-              },
-            }
-          );
-          dispatch(
-            setUserInfoChange({ profileImage: modifyInfo.profileImage })
-          );
-          setModifyType('');
-        } catch (error) {
-          alert('오류가 발생했습니다. 다시 시도해주세요.');
-        }
-        break;
-      case '닉네임':
-        if (!rnickname.test(modifyInfo.nickname)) {
-          alert('닉네임은 2~8자의 한글, 영문 또는 숫자로만 가능합니다.');
-          return;
-        }
-
-        try {
-          await axios.patch(
-            `${process.env.NEXT_PUBLIC_BASE_URL}/profile/nickname`,
-            { nickname: modifyInfo.nickname },
-            {
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-              },
-            }
-          );
-
-          dispatch(setUserInfoChange({ nickname: modifyInfo.nickname }));
-          setModifyType('');
-        } catch (error) {
-          if (error.response.data.message === '이미 사용중인 닉네임입니다.') {
-            alert('이미 사용중인 닉네임입니다.');
-            setModifyType('닉네임');
-            setModifyInfo((prevState) => ({
-              ...prevState,
-              nickname: nickname, // 현재 입력된 닉네임 유지
-            }));
-          }
-        }
-        break;
-
-      default:
-        break;
-    }
-  };
-
-  // 이미지 불러오기
-  const hanldeImage = async (e) => {
-    if (!e.target.value) return;
-    const image = e.target.files[0];
-    const uploaded = await getImage(image);
-    if (uploaded) setModifyInfo({ profileImage: uploaded });
-    e.target.value = ''; // 연속적으로 같은 값이 들어오도록 값을 비워줌
-  };
-
-  // 버튼 클릭 시 input 호출
-  const handleUploadClick = (e) => {
-    if (!imageRef.current) {
-      return;
-    }
-    imageRef.current.click();
-  };
-
   return (
     <section className="ml-[250px] px-[40px] py-[30px] min-h-[680px]">
       <h1 className="text-[32px] font-bold">회원 정보</h1>
       <small>{nickname}님의 계정 정보를 확인하고 변경하실 수 있습니다.</small>
       <section className="mt-[40px] flex flex-col gap-[36px] mb-[24px]">
-        <article className="mypage-profile">
-          <div className="flex items-center">
-            <h2 className="mypage-profile__label">
-              프로필
-              <br />
-              이미지
-            </h2>
-            <div className="flex gap-[24px] items-center">
-              <Image
-                className="w-[150px] h-[150px] rounded-full border mb-[12px]"
-                src={modifyInfo.profileImage || profile}
-                alt="profile"
-                width={150}
-                height={150}
-              />
-              {modifyType === '프로필이미지' && (
-                <div className="flex flex-col gap-[4px]">
-                  <button
-                    className="border rounded-lg text-sm px-[16px] py-[4px]"
-                    onClick={handleUploadClick}
-                  >
-                    프로필 변경
-                  </button>
-                  <input
-                    ref={imageRef}
-                    type="file"
-                    className="hidden"
-                    onChange={hanldeImage}
-                  />
-                  <button
-                    className="border rounded-lg text-sm px-[16px] py-[4px]"
-                    onClick={() => {
-                      setModifyInfo((prevState) => ({
-                        ...prevState,
-                        profileImage: null,
-                      }));
-                    }}
-                  >
-                    프로필 삭제
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="flex gap-[12px]">
-            {modifyType === '프로필이미지' && (
-              <button
-                className="mypage-profile__button"
-                onClick={handleModifyCancel}
-              >
-                변경취소
-              </button>
-            )}
-            <button
-              className={`mypage-profile__button ${modifyType === '프로필이미지' && 'mypage-profile__button-finish'}`}
-              onClick={(e) =>
-                modifyType === '프로필이미지'
-                  ? handleModifyComplete(e)
-                  : handleModifyType('프로필이미지')
-              }
-            >
-              {modifyType === '프로필이미지' ? '변경완료' : '변경'}
-            </button>
-          </div>
-        </article>
-        <article className="mypage-profile">
-          <div className="flex items-center">
-            <h2 className="mypage-profile__label">닉네임</h2>
-            {modifyType === '닉네임' ? (
-              <input
-                className="px-[8px] py-[4px] border rounded-lg outline-none"
-                value={modifyInfo.nickname || ''}
-                onChange={(e) =>
-                  setModifyInfo((prevState) => ({
-                    ...prevState,
-                    nickname: e.target.value,
-                  }))
-                }
-                placeholder="닉네임"
-              />
-            ) : (
-              <p className="mypage-profile__value">{nickname}</p>
-            )}
-          </div>
-          <div className="flex gap-[12px]">
-            {modifyType === '닉네임' && (
-              <button
-                className="mypage-profile__button"
-                onClick={handleModifyCancel}
-              >
-                변경취소
-              </button>
-            )}
-            <button
-              className={`mypage-profile__button ${modifyType === '닉네임' && 'mypage-profile__button-finish'}`}
-              onClick={(e) => {
-                modifyType === '닉네임'
-                  ? handleModifyComplete(e)
-                  : handleModifyType('닉네임');
-              }}
-            >
-              {modifyType === '닉네임' ? '변경완료' : '변경'}
-            </button>
-          </div>
-        </article>
+        <ModifyProfileImg
+          modifyInfo={modifyInfo}
+          setModifyInfo={setModifyInfo}
+        />
+        <ModifyNickname modifyInfo={modifyInfo} setModifyInfo={setModifyInfo} />
         <ModifyLocation />
         <ModifyNumber userInfo={userInfo} setUserInfo={setUserInfo} />
         <AccountInfo userInfo={userInfo} />

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 import DeliveryAddress from '@/app/_components/_mypage/DeliveryAddress';
 import Image from 'next/image';
 import Link from 'next/link';
+import ModifyNumber from '@/app/_components/_mypage/_modify/ModifyNumber';
 import Withdraw from '@/app/_components/_mypage/Withdraw';
 import axios from 'axios';
 import getImage from '@/app/_components/GetImage';
@@ -72,29 +73,6 @@ export default function Info() {
         phone: JSON.parse(sessionStorage.getItem('user'))?.phone,
       });
     }
-  }, []);
-
-  // 휴대폰 번호 변경 체크
-  useEffect(() => {
-    const handleMessage = (event) => {
-      if (event.origin !== window.location.origin) return;
-
-      if (event.data && event.data.type === 'UPDATE_PHONE') {
-        setUserInfo((prev) => ({
-          ...prev,
-          phone: event.data.phone,
-        }));
-
-        const user = JSON.parse(sessionStorage.getItem('user'));
-        user.phone = event.data.phone;
-        sessionStorage.setItem('user', JSON.stringify(user));
-      }
-    };
-
-    window.addEventListener('message', handleMessage);
-    return () => {
-      window.removeEventListener('message', handleMessage);
-    };
   }, []);
 
   const handleModifyType = (type) => {
@@ -339,26 +317,7 @@ export default function Info() {
             재설정
           </button>
         </article>
-        <article className="mypage-profile">
-          <div className="flex items-center">
-            <h2 className="mypage-profile__label">전화번호</h2>
-            <p className="mypage-profile__value">{userInfo.phone}</p>
-          </div>
-          <div className="flex gap-[12px]">
-            <button
-              className="mypage-profile__button"
-              onClick={() => {
-                window.open(
-                  '/change-number',
-                  '휴대폰 번호 변경',
-                  'width=620, height=670, location=1'
-                );
-              }}
-            >
-              변경
-            </button>
-          </div>
-        </article>
+        <ModifyNumber userInfo={userInfo} setUserInfo={setUserInfo} />
         <article className="mypage-profile">
           <div className="flex items-center">
             <h2 className="mypage-profile__label">계정정보</h2>

--- a/dutchiepay/src/app/(routes)/mypage/info/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/info/page.jsx
@@ -6,16 +6,14 @@ import '@/styles/mypage.css';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useRef, useState } from 'react';
 
+import AccountInfo from '@/app/_components/_mypage/AccountInfo';
 import DeliveryAddress from '@/app/_components/_mypage/DeliveryAddress';
 import Image from 'next/image';
-import Link from 'next/link';
 import ModifyLocation from '@/app/_components/_mypage/_modify/ModifyLocation';
 import ModifyNumber from '@/app/_components/_mypage/_modify/ModifyNumber';
 import Withdraw from '@/app/_components/_mypage/Withdraw';
 import axios from 'axios';
 import getImage from '@/app/_components/GetImage';
-import kakao from '../../../../../public/image/kakao.png';
-import naver from '../../../../../public/image/naver.png';
 import profile from '../../../../../public/image/profile.jpg';
 import { setUserInfoChange } from '@/redux/slice/loginSlice';
 
@@ -25,7 +23,6 @@ export default function Info() {
   const accessToken = useSelector((state) => state.login.access);
   const dispatch = useDispatch();
 
-  const [loginType, setLoginType] = useState(''); // email/kakao/naver
   const [userInfo, setUserInfo] = useState({
     email: null,
     phone: null,
@@ -38,11 +35,8 @@ export default function Info() {
   const imageRef = useRef(null);
   const rnickname = /^[a-zA-Z0-9가-힣]{2,8}$/;
 
-  // loginType과 email/phone API 호출 및 session 저장
+  // email/phone API 호출 및 session 저장
   useEffect(() => {
-    const storedLoginType = localStorage.getItem('loginType');
-    setLoginType(storedLoginType || '');
-
     const initMypage = async () => {
       try {
         const response = await axios.get(
@@ -285,45 +279,7 @@ export default function Info() {
         </article>
         <ModifyLocation />
         <ModifyNumber userInfo={userInfo} setUserInfo={setUserInfo} />
-        <article className="mypage-profile">
-          <div className="flex items-center">
-            <h2 className="mypage-profile__label">계정정보</h2>
-            {loginType === 'email' ? (
-              <p className="mypage-profile__value">{userInfo.email}</p>
-            ) : loginType === 'kakao' ? (
-              <div className="flex items-center gap-[12px]">
-                <Image
-                  className="w-[28px] h-[28px] rounded-full"
-                  src={kakao}
-                  alt="kakao"
-                  width={30}
-                  height={30}
-                />
-                <p>카카오 연동중</p>
-              </div>
-            ) : (
-              <div className="flex items-center gap-[12px]">
-                <Image
-                  className="w-[28px] h-[28px] rounded-full"
-                  src={naver}
-                  alt="naver"
-                  width={30}
-                  height={30}
-                />
-                <p>네이버 연동중</p>
-              </div>
-            )}
-          </div>
-          {loginType === 'email' && (
-            <Link
-              href="/reset"
-              className="mypage-profile__button-reset"
-              role="button"
-            >
-              비밀번호 변경
-            </Link>
-          )}
-        </article>
+        <AccountInfo userInfo={userInfo} />
         <DeliveryAddress />
         <Withdraw />
       </section>

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -189,14 +189,16 @@ export default function Header() {
                 height={40}
                 src={chat}
               />
-              <Image
-                className="w-[55px] h-[55px] rounded-full border ml-[18px] cursor-pointer"
-                src={user?.profileImage || profile}
-                alt="profile"
-                width={55}
-                height={55}
-                onClick={() => router.push('/mypage')}
-              />
+              <div className="relative w-[55px] h-[55px] ml-[18px] cursor-pointer">
+                <Image
+                  className="rounded-full border"
+                  src={user?.profileImage || profile}
+                  alt="profile"
+                  fill
+                  style={{ objectFit: 'cover' }}
+                  onClick={() => router.push('/mypage')}
+                />
+              </div>
             </div>
           )}
         </div>

--- a/dutchiepay/src/app/_components/_layout/Sidebar.jsx
+++ b/dutchiepay/src/app/_components/_layout/Sidebar.jsx
@@ -33,13 +33,15 @@ export default function Sidebar() {
   return (
     <aside className="w-[250px] h-[730px] bg-white border-r px-[16px] py-[40px] mb-[70px] flex flex-col items-center gap-[32px] fixed">
       <div className="flex flex-col items-center">
-        <Image
-          className="w-[120px] h-[120px] rounded-full border mb-[12px]"
-          src={userInfo?.profileImage || profile}
-          alt="profile"
-          width={120}
-          height={120}
-        />
+        <div className="relative w-[120px] h-[120px] mb-[12px]">
+          <Image
+            className="rounded-full border"
+            src={userInfo?.profileImage || profile}
+            alt="profile"
+            fill
+            style={{ objectFit: 'cover' }}
+          />
+        </div>
         <strong>{userInfo?.nickname}</strong>
       </div>
       <ul>

--- a/dutchiepay/src/app/_components/_mypage/AccountInfo.jsx
+++ b/dutchiepay/src/app/_components/_mypage/AccountInfo.jsx
@@ -1,0 +1,62 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/mypage.css';
+
+import { useEffect, useState } from 'react';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import kakao from '/public/image/kakao.png';
+import naver from '/public/image/naver.png';
+
+export default function AccountInfo({ userInfo }) {
+  const [loginType, setLoginType] = useState(''); // email/kakao/naver
+
+  useEffect(() => {
+    const storedLoginType = localStorage.getItem('loginType');
+    setLoginType(storedLoginType || '');
+  }, []);
+
+  return (
+    <article className="mypage-profile">
+      <div className="flex items-center">
+        <h2 className="mypage-profile__label">계정정보</h2>
+        {loginType === 'email' ? (
+          <p className="mypage-profile__value">{userInfo.email}</p>
+        ) : loginType === 'kakao' ? (
+          <div className="flex items-center gap-[12px]">
+            <Image
+              className="w-[28px] h-[28px] rounded-full"
+              src={kakao}
+              alt="kakao"
+              width={30}
+              height={30}
+            />
+            <p>카카오 연동중</p>
+          </div>
+        ) : (
+          <div className="flex items-center gap-[12px]">
+            <Image
+              className="w-[28px] h-[28px] rounded-full"
+              src={naver}
+              alt="naver"
+              width={30}
+              height={30}
+            />
+            <p>네이버 연동중</p>
+          </div>
+        )}
+      </div>
+      {loginType === 'email' && (
+        <Link
+          href="/reset"
+          className="mypage-profile__button-reset"
+          role="button"
+        >
+          비밀번호 변경
+        </Link>
+      )}
+    </article>
+  );
+}

--- a/dutchiepay/src/app/_components/_mypage/_modify/ModifyLocation.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_modify/ModifyLocation.jsx
@@ -1,0 +1,58 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/mypage.css';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import axios from 'axios';
+import getLocation from '@/app/_components/_user/GetLocation';
+import { setUserInfoChange } from '@/redux/slice/loginSlice';
+
+export default function ModifyLocation() {
+  const location = useSelector((state) => state.login.user.location);
+  const accessToken = useSelector((state) => state.login.access);
+  const dispatch = useDispatch();
+
+  const handleGetCurrentLocation = async () => {
+    if (confirm('지역을 재설정 하시겠습니까?')) {
+      const newLocation = await getLocation();
+      if (location === newLocation) {
+        alert(
+          '기존과 동일한 지역에 위치하여 변경되지 않습니다.\n지역은 임의로 변경이 불가능합니다.'
+        );
+        return;
+      }
+
+      try {
+        await axios.patch(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/profile/location`,
+          { location: newLocation },
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+        dispatch(setUserInfoChange({ location: newLocation }));
+      } catch (error) {
+        alert('오류가 발생했습니다. 다시 시도해주세요.');
+      }
+    }
+  };
+
+  return (
+    <article className="mypage-profile">
+      <div className="flex items-center">
+        <h2 className="mypage-profile__label">지역</h2>
+        <p className="mypage-profile__value">{location}</p>
+      </div>
+      <button
+        className="mypage-profile__button"
+        onClick={handleGetCurrentLocation}
+      >
+        재설정
+      </button>
+    </article>
+  );
+}

--- a/dutchiepay/src/app/_components/_mypage/_modify/ModifyNickname.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_modify/ModifyNickname.jsx
@@ -1,0 +1,93 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/mypage.css';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import axios from 'axios';
+import { setUserInfoChange } from '@/redux/slice/loginSlice';
+import { useState } from 'react';
+
+export default function ModifyNickname({ modifyInfo, setModifyInfo }) {
+  const nickname = useSelector((state) => state.login.user.nickname);
+  const access = useSelector((state) => state.login.access);
+  const [isModify, setIsModify] = useState(false);
+  const rnickname = /^[a-zA-Z0-9가-힣]{2,8}$/;
+  const dispatch = useDispatch();
+
+  const handleModifyCancel = () => {
+    setModifyInfo((prevModifyInfo) => ({
+      ...prevModifyInfo,
+      nickname: nickname,
+    }));
+    setIsModify(false);
+  };
+
+  const handleModifyComplete = async () => {
+    if (!rnickname.test(modifyInfo.nickname)) {
+      alert('닉네임은 2~8자의 한글, 영문 또는 숫자로만 가능합니다.');
+      return;
+    }
+
+    try {
+      await axios.patch(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/profile/nickname`,
+        { nickname: modifyInfo.nickname },
+        {
+          headers: {
+            Authorization: `Bearer ${access}`,
+          },
+        }
+      );
+
+      dispatch(setUserInfoChange({ nickname: modifyInfo.nickname }));
+      setIsModify(false);
+    } catch (error) {
+      if (error.response.data.message === '이미 사용중인 닉네임입니다.') {
+        alert('이미 사용중인 닉네임입니다.');
+      }
+    }
+  };
+
+  return (
+    <article className="mypage-profile">
+      <div className="flex items-center">
+        <h2 className="mypage-profile__label">닉네임</h2>
+        {isModify ? (
+          <input
+            className="px-[8px] py-[4px] border rounded-lg outline-none"
+            value={modifyInfo.nickname || ''}
+            onChange={(e) =>
+              setModifyInfo((prevState) => ({
+                ...prevState,
+                nickname: e.target.value,
+              }))
+            }
+            placeholder="닉네임"
+          />
+        ) : (
+          <p className="mypage-profile__value">{nickname}</p>
+        )}
+      </div>
+      <div className="flex gap-[12px]">
+        {isModify && (
+          <button
+            className="mypage-profile__button"
+            onClick={handleModifyCancel}
+          >
+            변경취소
+          </button>
+        )}
+        <button
+          className={`mypage-profile__button ${isModify && 'mypage-profile__button-finish'}`}
+          onClick={() => {
+            isModify ? handleModifyComplete() : setIsModify(!isModify);
+          }}
+        >
+          {isModify ? '변경완료' : '변경'}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/dutchiepay/src/app/_components/_mypage/_modify/ModifyNumber.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_modify/ModifyNumber.jsx
@@ -1,0 +1,52 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/mypage.css';
+
+import { useEffect } from 'react';
+
+export default function ModifyNumber({ userInfo, setUserInfo }) {
+  // 휴대폰 번호 변경 체크
+  useEffect(() => {
+    const handleMessage = (event) => {
+      if (event.origin !== window.location.origin) return;
+
+      if (event.data && event.data.type === 'UPDATE_PHONE') {
+        setUserInfo((prev) => ({
+          ...prev,
+          phone: event.data.phone,
+        }));
+
+        const user = JSON.parse(sessionStorage.getItem('user'));
+        user.phone = event.data.phone;
+        sessionStorage.setItem('user', JSON.stringify(user));
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  return (
+    <article className="mypage-profile">
+      <div className="flex items-center">
+        <h2 className="mypage-profile__label">전화번호</h2>
+        <p className="mypage-profile__value">{userInfo.phone}</p>
+      </div>
+      <button
+        className="mypage-profile__button"
+        onClick={() => {
+          window.open(
+            '/change-number',
+            '휴대폰 번호 변경',
+            'width=620, height=670, location=1'
+          );
+        }}
+      >
+        변경
+      </button>
+    </article>
+  );
+}

--- a/dutchiepay/src/app/_components/_mypage/_modify/ModifyProfileImg.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_modify/ModifyProfileImg.jsx
@@ -1,0 +1,88 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/mypage.css';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import Image from 'next/image';
+import ProfileImgButton from './ProfileImgButton';
+import axios from 'axios';
+import profile from '/public/image/profile.jpg';
+import { setUserInfoChange } from '@/redux/slice/loginSlice';
+import { useState } from 'react';
+
+export default function ModifyProfileImg({ modifyInfo, setModifyInfo }) {
+  const profileImage = useSelector((state) => state.login.user.profileImage);
+  const access = useSelector((state) => state.login.access);
+  const [isModify, setIsModify] = useState(false);
+  const dispatch = useDispatch();
+
+  const handleModifyCancel = () => {
+    setModifyInfo((prevModifyInfo) => ({
+      ...prevModifyInfo,
+      profileImage: profileImage,
+    }));
+    setIsModify(false);
+  };
+
+  const handleModifyComplete = async () => {
+    try {
+      await axios.patch(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/profile/image`,
+        { profileImg: modifyInfo.profileImage },
+        {
+          headers: {
+            Authorization: `Bearer ${access}`,
+          },
+        }
+      );
+      dispatch(setUserInfoChange({ profileImage: modifyInfo.profileImage }));
+      setIsModify(false);
+    } catch (error) {
+      alert('오류가 발생했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  return (
+    <article className="mypage-profile">
+      <div className="flex items-center">
+        <h2 className="mypage-profile__label">
+          프로필
+          <br />
+          이미지
+        </h2>
+        <div className="flex gap-[24px] items-center">
+          <div className="relative w-[150px] h-[150px] mb-[12px]">
+            <Image
+              className="rounded-full border"
+              src={modifyInfo.profileImage || profile}
+              alt="profile"
+              fill
+              style={{ objectFit: 'cover' }}
+            />
+          </div>
+          {isModify && <ProfileImgButton setModifyInfo={setModifyInfo} />}
+        </div>
+      </div>
+      <div className="flex gap-[12px]">
+        {isModify && (
+          <button
+            className="mypage-profile__button"
+            onClick={handleModifyCancel}
+          >
+            변경취소
+          </button>
+        )}
+        <button
+          className={`mypage-profile__button ${isModify && 'mypage-profile__button-finish'}`}
+          onClick={() =>
+            isModify ? handleModifyComplete() : setIsModify(!isModify)
+          }
+        >
+          {isModify ? '변경완료' : '변경'}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/dutchiepay/src/app/_components/_mypage/_modify/ProfileImgButton.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_modify/ProfileImgButton.jsx
@@ -1,0 +1,56 @@
+'use client';
+
+import '@/styles/globals.css';
+import '@/styles/mypage.css';
+
+import getImage from '@/app/_components/GetImage';
+import { useRef } from 'react';
+
+export default function ProfileImgButton({ setModifyInfo }) {
+  const imageRef = useRef(null);
+
+  // 이미지 불러오기
+  const hanldeImage = async (e) => {
+    if (!e.target.value) return;
+    const image = e.target.files[0];
+    const uploaded = await getImage(image);
+    if (uploaded) setModifyInfo({ profileImage: uploaded });
+    e.target.value = ''; // 연속적으로 같은 값이 들어오도록 값을 비워줌
+  };
+
+  // 버튼 클릭 시 input 호출
+  const handleUploadClick = (e) => {
+    if (!imageRef.current) {
+      return;
+    }
+    imageRef.current.click();
+  };
+
+  return (
+    <div className="flex flex-col gap-[4px]">
+      <button
+        className="border rounded-lg text-sm px-[16px] py-[4px]"
+        onClick={handleUploadClick}
+      >
+        프로필 변경
+      </button>
+      <input
+        ref={imageRef}
+        type="file"
+        className="hidden"
+        onChange={hanldeImage}
+      />
+      <button
+        className="border rounded-lg text-sm px-[16px] py-[4px]"
+        onClick={() => {
+          setModifyInfo((prevState) => ({
+            ...prevState,
+            profileImage: null,
+          }));
+        }}
+      >
+        프로필 삭제
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인
- [x] 리팩토링

## 반영 브랜치
refactor/split-info

## 변경 사항
1. 변경과 관련된 컴포넌트들을 _mypage 내 _modify 폴더로 한 곳에 두었습니다.
2. 각 article을 컴포넌트로 분리했습니다. 이에 따라 modifyType이 불필요해져 해당 변수는 제거하였습니다. -> modifyInfo 또한 컴포넌트 내에 별도로 관리되도록 수정할  수 있으나 user와는 달리 props로 전달되는 것이 많지 않고 props drilling이 거의 발생하지 않아 현재는 하지 않았습니다.
3.  axios 오류 시 불필요하게 modifyInfo를 다시 덮어쓰지 않아도 값이 유지되고 있어 해당 코드를 제거했습니다.
4. 지역 변경 시 기존과 동일할 경우 alert를 통해 변경될 사항이 없음을 알려주고 axios를 호출하지 않도록 하였습니다.
5. location 변수가 중복 사용되어 유지보수를 위해 새로운 location을 newLocation으로 변경했습니다.
6. 프로필 이미지의 비율이 원본 비율을 유지하지 않아 fill + cover 속성을 추가해주었습니다.

## 테스트 결과
기존과 동일하게 작동합니다.

## ETC
컴포넌트를 유지보수를 위해 분리하였으나 현재 모든 컴포넌트가 동시에 렌더링되고 있어 성능저하가 발생하게 됩니다. Pre-fetching과 Lazy Loading을 이용하면 이전보다 더 좋은 성능을 보일 것으로 보입니다. 다만, 해당 부분까지 진행하기에는 이미 유저 기능 구현 자체는 끝난 상황이기에 추후 리팩토링으로 보완하는 쪽으로 생각하면 될 것 같습니다.
