### PR TITLE
[fix] sidebar가 footer를 가리는 현상 수정

### DIFF
--- a/dutchiepay/src/app/_components/_layout/Footer.jsx
+++ b/dutchiepay/src/app/_components/_layout/Footer.jsx
@@ -8,7 +8,7 @@ import notion from '../../../../public/image/notion.svg';
 
 export default function Footer() {
   return (
-    <footer className="border-t">
+    <footer className="relative border-t z-50 bg-white">
       <div className="w-[1020px] m-0 m-auto ">
         <div className="flex items-center w-full justify-between">
           <div className="flex gap-[30px] items-center">

--- a/dutchiepay/src/app/_components/_layout/Sidebar.jsx
+++ b/dutchiepay/src/app/_components/_layout/Sidebar.jsx
@@ -5,17 +5,17 @@ import '@/styles/globals.css';
 
 import Image from 'next/image';
 import Link from 'next/link';
-import arrow from '../../../../public/image/arrow.svg';
-import delivery from '../../../../public/image/delivery.svg';
-import heart from '../../../../public/image/heart.svg';
-import post from '../../../../public/image/post.svg';
-import profile from '../../../../public/image/profile.jpg';
-import question from '../../../../public/image/question.svg';
-import review from '../../../../public/image/review.svg';
+import arrow from '/public/image/arrow.svg';
+import delivery from '/public/image/delivery.svg';
+import heart from '/public/image/heart.svg';
+import post from '/public/image/post.svg';
+import profile from '/public/image/profile.jpg';
+import question from '/public/image/question.svg';
+import review from '/public/image/review.svg';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
-import userIcon from '../../../../public/image/user.svg';
+import userIcon from '/public/image/user.svg';
 
 export default function Sidebar() {
   const userInfo = useSelector((state) => state.login.user);
@@ -31,7 +31,7 @@ export default function Sidebar() {
   }, []);
 
   return (
-    <aside className="w-[250px] h-[730px] bg-white border-r px-[16px] py-[40px] mb-[70px] flex flex-col items-center gap-[32px] fixed">
+    <aside className="fixed w-[250px] bg-white px-[16px] py-[40px] flex flex-col items-center gap-[32px] z-10">
       <div className="flex flex-col items-center">
         <div className="relative w-[120px] h-[120px] mb-[12px]">
           <Image


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 디자인

## 반영 브랜치
fix/sidebar -> main

## 변경 사항
1. sidebar border 제거
2. sidebar가 footer를 가리지 않도록 수정

## 테스트 결과
![image](https://github.com/user-attachments/assets/fef51000-5258-4f6a-aab1-09c79cef27b0)

## ETC
sidebar의 border가 모든 디바이스를 기준으로 sidebar와 content를 구분짓지 못하는 것 같아 sidebar와 content 사이를 구분짓지 않으려고 합니다. 다만 이에 따라 sidebar 하단이 다소 허전해질 수 있습니다.
sidebar가 최소 height를 보장받지 못하면 모든 영역이 표시되지 못하고 있습니다. 다만 특정 해상도에서는 대부분 다 표시되고 있어 해당 부분에 대해서는 협의가 필요할 것 같습니다. 일단은 UI적으로 문제가 되는 부분만 수정했습니다.