### PR TITLE
[Fix] validation 오류 수정 및 user 관련 페이지 logo warning 해결

### DIFF
--- a/dutchiepay/src/app/_components/_user/Logo.jsx
+++ b/dutchiepay/src/app/_components/_user/Logo.jsx
@@ -14,6 +14,7 @@ export default function Logo() {
           alt="logo"
           width={200}
           height={120}
+          priority
         />
       </Link>
     </h1>

--- a/dutchiepay/src/app/_components/_user/_input/ConfirmPassword.jsx
+++ b/dutchiepay/src/app/_components/_user/_input/ConfirmPassword.jsx
@@ -17,7 +17,6 @@ export default function ConfirmPassword({
 }) {
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false);
-  const rPassword = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*_-]).{8,}$/;
 
   return (
     <>
@@ -35,12 +34,12 @@ export default function ConfirmPassword({
           className={`user__input-password mt-[4px] ${
             touchedFields.confirmPassword &&
             errors.confirmPassword &&
-            rPassword.test(newPassword)
+            !errors.newPassword
               ? 'user__input-password__invalid'
               : touchedFields.confirmPassword &&
                   !errors.confirmPassword &&
                   confirmPassword &&
-                  rPassword.test(newPassword)
+                  !errors.newPassword
                 ? 'user__input-password__valid'
                 : ''
           }`}
@@ -49,7 +48,7 @@ export default function ConfirmPassword({
           type={isConfirmPasswordVisible ? 'text' : 'password'}
           {...register('confirmPassword', {
             validate: (value) => {
-              if (newPassword && rPassword.test(newPassword)) {
+              if (newPassword && !errors.newPassword) {
                 return value === newPassword || '비밀번호가 일치하지 않습니다.';
               }
               return false; // newPassword가 유효하지 않으면 항상 false 반환
@@ -70,11 +69,14 @@ export default function ConfirmPassword({
         role="alert"
         aria-hidden={errors.confirmPassword ? 'true' : 'false'}
       >
-        {touchedFields.confirmPassword && errors.confirmPassword
+        {touchedFields.confirmPassword &&
+        errors.confirmPassword &&
+        !errors.newPassword
           ? errors.confirmPassword.message
           : touchedFields.confirmPassword &&
               !errors.confirmPassword &&
-              confirmPassword
+              confirmPassword &&
+              !errors.newPassword
             ? '두 비밀번호가 일치합니다'
             : ''}
       </p>

--- a/dutchiepay/src/app/_components/_user/_input/ConfirmPassword.jsx
+++ b/dutchiepay/src/app/_components/_user/_input/ConfirmPassword.jsx
@@ -34,7 +34,8 @@ export default function ConfirmPassword({
           className={`user__input-password mt-[4px] ${
             touchedFields.confirmPassword &&
             errors.confirmPassword &&
-            !errors.newPassword
+            !errors.newPassword &&
+            newPassword
               ? 'user__input-password__invalid'
               : touchedFields.confirmPassword &&
                   !errors.confirmPassword &&

--- a/dutchiepay/src/app/_components/_user/_input/EmailInput.jsx
+++ b/dutchiepay/src/app/_components/_user/_input/EmailInput.jsx
@@ -91,7 +91,7 @@ export default function EmailInput({
           errors.email ? 'text-red--500' : 'text-blue--500'
         }`}
         role="alert"
-        aria-hidden={errors.email ? 'true' : 'false'}
+        aria-hidden={!touchedFields.email || !errors.email ? 'true' : 'false'}
       >
         {touchedFields.email && errors.email
           ? errors.email.message

--- a/dutchiepay/src/app/_components/_user/_input/EmailInput.jsx
+++ b/dutchiepay/src/app/_components/_user/_input/EmailInput.jsx
@@ -31,17 +31,15 @@ export default function EmailInput({
       if (error.response.data.message === '이미 사용중인 이메일입니다.') {
         setError('email', {
           type: 'manual',
-          message: '이미 사용중인 이메일입니다',
+          message: '이미 사용중인 이메일입니다.',
         });
-      } else if (error.response.data.message === '탈퇴한 회원입니다.') {
+      } else if (
+        error.response.data.message === '탈퇴한 회원입니다.' ||
+        error.response.data.message === '정지된 회원입니다.'
+      ) {
         setError('email', {
           type: 'manual',
-          message: '탈퇴된 이메일입니다',
-        });
-      } else if (error.response.data.message === '정지된 회원입니다.') {
-        setError('email', {
-          type: 'manual',
-          message: '정지된 이메일입니다',
+          message: '탈퇴 또는 정지된 이메일입니다.',
         });
       }
       setIsEmailAvailable(false);
@@ -55,11 +53,11 @@ export default function EmailInput({
         className={`user__input mt-[4px] ${
           touchedFields.email && errors.email
             ? 'user__input__invalid'
-            : touchedFields.email && !errors.email && email
-              ? isSignup
+            : touchedFields.email && !errors.email && email && isEmailAvailable
+              ? 'user__input__valid'
+              : touchedFields.email && !errors.email && email && !isSignup
                 ? 'user__input__valid'
                 : ''
-              : ''
         }`}
         type="email"
         placeholder="이메일"
@@ -80,6 +78,12 @@ export default function EmailInput({
               }
             }
           },
+          onChange: (e) => {
+            if (isEmailAvailable && e.target.value !== email) {
+              setIsEmailAvailable(null);
+              clearErrors('email');
+            }
+          },
         })}
       />
       <p
@@ -89,17 +93,11 @@ export default function EmailInput({
         role="alert"
         aria-hidden={errors.email ? 'true' : 'false'}
       >
-        {isSignup
-          ? touchedFields.email && errors.email
-            ? errors.email.message
-            : touchedFields.email && !errors.email && email && isEmailAvailable
-              ? '사용가능한 이메일 입니다'
-              : touchedFields.email && !errors.email && email
-                ? '올바른 이메일 형식입니다.'
-                : ''
-          : errors.email
-            ? errors.email.message
-            : touchedFields.email && !errors.email && email
+        {touchedFields.email && errors.email
+          ? errors.email.message
+          : touchedFields.email && !errors.email && email && isEmailAvailable
+            ? '사용가능한 이메일 입니다.'
+            : touchedFields.email && !errors.email && email && !isSignup
               ? '올바른 이메일 형식입니다.'
               : ''}
       </p>

--- a/dutchiepay/src/app/_components/_user/_input/NicknameInput.jsx
+++ b/dutchiepay/src/app/_components/_user/_input/NicknameInput.jsx
@@ -2,6 +2,7 @@
 
 import '@/styles/globals.css';
 import '@/styles/user.css';
+
 import axios from 'axios';
 import { useState } from 'react';
 
@@ -25,11 +26,8 @@ export default function NicknameInput({
         `${process.env.NEXT_PUBLIC_BASE_URL}/users?nickname=${value}`
       );
       setIsNicknameAvailable(true);
-      clearErrors('nickname'); // 사용 가능한 닉네임이므로 오류를 클리어
+      clearErrors('nickname');
     } catch (error) {
-      console.log(error.response.data);
-
-      // 400 오류가 발생하면 nickname에 대한 오류를 설정
       if (error.response.data.message === '이미 사용중인 닉네임입니다.') {
         setError('nickname', {
           type: 'manual',
@@ -56,7 +54,10 @@ export default function NicknameInput({
           className={`user__input mt-[4px] ${
             touchedFields.nickname && errors.nickname
               ? 'user__input__invalid'
-              : touchedFields.nickname && !errors.nickname && nickname
+              : touchedFields.nickname &&
+                  !errors.nickname &&
+                  nickname &&
+                  isNicknameAvailable
                 ? 'user__input__valid'
                 : ''
           }`}
@@ -79,6 +80,12 @@ export default function NicknameInput({
                 setIsNicknameAvailable(null); // 패턴이 유효하지 않을 경우 가용성 초기화
               }
             },
+            onChange: (e) => {
+              if (isNicknameAvailable && e.target.value !== nickname) {
+                setIsNicknameAvailable(null);
+                clearErrors('nickname');
+              }
+            },
           })}
         />
       </div>
@@ -87,7 +94,9 @@ export default function NicknameInput({
           nickname && !errors.nickname ? 'text-blue--500' : 'text-red--500'
         }`}
         role="alert"
-        aria-hidden={errors.nickname ? 'true' : 'false'}
+        aria-hidden={
+          !touchedFields.nickname || !errors.nickname ? 'true' : 'false'
+        }
       >
         {touchedFields.nickname && errors.nickname
           ? errors.nickname.message
@@ -96,9 +105,7 @@ export default function NicknameInput({
               nickname &&
               isNicknameAvailable
             ? '사용가능한 닉네임 입니다'
-            : touchedFields.nickname && !errors.nickname && nickname
-              ? '올바른 닉네임 형식입니다.'
-              : ''}
+            : ''}
       </p>
     </>
   );

--- a/dutchiepay/src/app/_components/_user/_input/PasswordInput.jsx
+++ b/dutchiepay/src/app/_components/_user/_input/PasswordInput.jsx
@@ -1,19 +1,28 @@
+'use client';
+
 import '@/styles/globals.css';
 import '@/styles/user.css';
 
 import ConfirmPassword from './ConfirmPassword';
 import CurrentPassword from './CurrentPassword';
 import NewPassword from './NewPassword';
+import { useEffect } from 'react';
 
 export default function PasswordInput({
   register,
   errors,
+  trigger,
   touchedFields,
   password,
   confirmPassword,
   newPassword,
   isReset = false,
 }) {
+  useEffect(() => {
+    // password 값이 변경될 때 비밀번호 확인 필드 유효성 검사를 트리거
+    trigger('confirmPassword');
+  }, [newPassword, trigger]);
+
   return (
     <>
       {isReset && (

--- a/dutchiepay/src/app/_components/_user/_signup/SignUpSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/_signup/SignUpSubmit.jsx
@@ -63,6 +63,7 @@ export default function SignUpSubmit() {
     }
   };
 
+  const password = watch('password');
   const newPassword = watch('newPassword');
   const confirmPassword = watch('confirmPassword');
   const nickname = watch('nickname');
@@ -89,6 +90,7 @@ export default function SignUpSubmit() {
         register={register}
         trigger={trigger}
         errors={errors}
+        password={password}
         newPassword={newPassword}
         confirmPassword={confirmPassword}
         touchedFields={touchedFields}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/validation -> main

## 변경 사항
1. 비밀번호 - 유효성 실패 && 비밀번호 확인 - 유효성 성공 상태에서 비밀번호를 비밀번호 확인과 동일한 값으로 변경할 경우, 비밀번호 확인의 유효성이 통과되지 않는 오류 수정
2. 비밀번호 - 유효성 성공 && 비밀번호 확인 - 유효성 성공 상태에서 값 하나를 변경 시에도 유효성 성공으로 표시되는 오류 수정
3. 회원가입에서 이메일과 닉네임의 유효성 성공 상태에서 각 데이터를 중복되는 값으로 변경 시 일시적으로 유효성 성공으로 표시되는 오류 수정
4. 로고 이미지의 priority 속성을 추가해 제일 먼저 렌더링될 수 있도록 설정

## 테스트 결과
즉각적으로 변하는 상황이라 테스트 화면을 캡쳐하기 애매하여 생략하였습니다. 모두 발견된 오류 및 일반적인 상황에서 제대로 동작하는 것을 확인했습니다.

## ETC
1. 비밀번호 확인의 유효성이 통과되지 않는 오류는 비밀번호가 변경된 뒤에 비밀번호 확인의 유효성 재검사가 진행되지 않고 있기 때문입니다. 이전에 삭제하신 trigger를 그대로 사용하면 해결되므로, 삭제된 trigger를 다시 추가해주었습니다.
2. 비밀번호 유효성이 성공한 뒤 계속 유효성이 성공으로 표시되는 이유는 border와 안내 문구 조건에 newPassword와 confirmPassword의 오류를 모두 고려하지 않기 때문입니다. confirmPassword의 유효성 오류 표시 조건에 newPassword의 error 상태를 고려하도록 조건을 추가해주었습니다.
3. 이메일과 닉네임의 값 변경 시 유효성 성공으로 표시되는 이유는 isAvaliable 값이 값이 변경될 때 초기화되지 않고 기존 값을 가지고 있기 때문입니다. 해당 값이 true인 상태에서 값이 변경될 경우 onChnage를 통해 해당 변수를 초기화해주었습니다. 또한, 회원가입 내에서는 패턴  규칙 통과 안내를 보여줄 필요가 없습니다. 규칙 통과 && 중복 통과 => 유효성 통과로 표시해야 하는데 규칙 통과 문구가 존재했기 때문에 일시적으로 규칙 통과 문구가 표시되었습니다. 또한 border, 안내문구의 조건이 동일하지 않은 상태였습니다. 유효성 체크하실 때 해당 부분 잘 확인해주시기 바랍니다.
