### PR TITLE
[refactor] 우편번호 불러오기 함수를 custom hooks로 변경

### DIFF
--- a/dutchiepay/src/app/(modals)/delivery-address/page.jsx
+++ b/dutchiepay/src/app/(modals)/delivery-address/page.jsx
@@ -7,18 +7,18 @@ import { useEffect, useState } from 'react';
 
 import CryptoJS from 'crypto-js';
 import axios from 'axios';
-import { useDaumPostcodePopup } from 'react-daum-postcode';
 import { useForm } from 'react-hook-form';
+import useGetPostCode from '@/app/hooks/useGetPostCode';
 import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
 export default function Address() {
   const searchParams = useSearchParams();
-  const open = useDaumPostcodePopup();
   const addressId = searchParams.get('addressid'); // 해당 값이 존재하면 수정, 존재하지 않으면 추가
   const access = useSelector((state) => state.login.access);
   const encryptedAddresses = useSelector((state) => state.address.addresses);
   const [isDefaultAddress, setIsDefaultAddress] = useState(false); // 수정 요청 주소지가 기본 배송지였을 경우 true
+  const getPostCode = useGetPostCode();
 
   const { register, handleSubmit, setValue } = useForm({
     mode: 'onSubmit',
@@ -117,17 +117,14 @@ export default function Address() {
     }
   };
 
-  const handlePostCode = () => {
-    open({
-      onComplete: (data) => {
-        setValue('zipCode', data.zonecode);
-        setValue('address', data.roadAddress);
-      },
-      width: 500,
-      height: 600,
-      left: window.innerWidth / 2 - 500 / 2,
-      top: window.innerHeight / 2 - 600 / 2,
-    });
+  const handlePostCode = async () => {
+    try {
+      const addressData = await getPostCode();
+      setValue('zipCode', addressData.zipCode);
+      setValue('address', addressData.address);
+    } catch (error) {
+      alert('오류가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
   const closeWindow = () => {

--- a/dutchiepay/src/app/_components/_commerce/Orderer.jsx
+++ b/dutchiepay/src/app/_components/_commerce/Orderer.jsx
@@ -5,7 +5,7 @@ import '@/styles/globals.css';
 
 import Image from 'next/image';
 import selectArrow from '../../../../public/image/selectArrow.svg';
-import { useDaumPostcodePopup } from 'react-daum-postcode';
+import useGetPostCode from '@/app/hooks/useGetPostCode';
 import { useState } from 'react';
 
 export default function Orderer() {
@@ -15,22 +15,19 @@ export default function Orderer() {
     address: '',
     detail: '',
   });
-  const open = useDaumPostcodePopup();
+  const getPostCode = useGetPostCode();
 
-  const handlePostCode = (e) => {
-    open({
-      onComplete: (data) => {
-        setAddressInfo((prevState) => ({
-          ...prevState,
-          zipCode: data.zonecode,
-          address: data.roadAddress,
-        }));
-      },
-      width: 500,
-      height: 600,
-      left: window.innerWidth / 2 - 500 / 2,
-      top: window.innerHeight / 2 - 600 / 2,
-    });
+  const handlePostCode = async () => {
+    try {
+      const addressData = await getPostCode();
+      setAddressInfo((prevState) => ({
+        ...prevState,
+        zipCode: addressData.zipCode,
+        address: addressData.address,
+      }));
+    } catch (error) {
+      alert('오류가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
   return (
@@ -63,7 +60,7 @@ export default function Orderer() {
                 <div className="flex items-center gap-[8px]">
                   <input
                     className="w-[70px] border rounded-lg px-[8px] py-[6px] text-sm outline-none"
-                    value={addressInfo.zipCode}
+                    value={addressInfo.zipCode || ''}
                     placeholder="우편번호"
                   />
                   <button
@@ -76,7 +73,7 @@ export default function Orderer() {
                 </div>
                 <input
                   className="border rounded-lg px-[8px] py-[6px] text-sm outline-none"
-                  value={addressInfo.address}
+                  value={addressInfo.address || ''}
                   placeholder="주소"
                 />
                 <input

--- a/dutchiepay/src/app/hooks/useGetPostCode.jsx
+++ b/dutchiepay/src/app/hooks/useGetPostCode.jsx
@@ -1,0 +1,24 @@
+import { useDaumPostcodePopup } from 'react-daum-postcode';
+
+export default function useGetPostCode() {
+  const open = useDaumPostcodePopup();
+
+  const getPostCode = () => {
+    return new Promise((resolve) => {
+      open({
+        onComplete: (data) => {
+          resolve({
+            zipCode: data.zonecode,
+            address: data.roadAddress,
+          });
+        },
+        width: 500,
+        height: 600,
+        left: window.innerWidth / 2 - 500 / 2,
+        top: window.innerHeight / 2 - 600 / 2,
+      });
+    });
+  };
+
+  return getPostCode;
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
refactor/postcode -> main

## 변경 사항
1. 중복돼서 사용되던 우편번호 불러오기 코드를 custom hooks로 변경해 중복되지 않도록 변경

## 테스트 결과
기존과 동일하게 동작합니다.

## ETC
현재 우편번호를 사용하는 페이지가 배송지 수정/추가, 주문 페이지에서 사용되고 있는데 두 군데에서 사용하는 값 (우편번호, 도로명주소)는 동일하지만 해당 값을 저장하는 방식이 다릅니다. 한 곳은 useState의 set 함수에 저장하고 한 곳은 react hook form에 setValue를 사용하고 있습니다. 그러다보니 onComplete 이후 내용을 하나로 통일하기가 어려워 필요한 값을 반환하는 식으로 사용했습니다.
값을 반환하기 때문에 custom hooks이 아닌 util 함수로 구현하려고 했으나 우편번호를 불러오는 useDaumPostcodePopup 자체가 React Hook이기 때문에 컴포넌트 또는 커스텀 훅 내부에 호출되어야 해서 custom hooks으로 구현하는 식으로 결정했습니다. 코드가 짧아지는 이점은 없으나 중복된 코드를 줄인다는 점에서 변경하게 됐습니다.
