### PR TITLE
[fix] 같은 브라우저 탭 내에서 session 데이터 공유되지 않는 오류 해결

### DIFF
--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -2,23 +2,17 @@
 
 import '@/styles/header.css';
 
-import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { usePathname, useRouter } from 'next/navigation';
 
-import Cookies from 'universal-cookie';
+import HeaderMain from './HeaderMain';
 import HeaderTop from './HeaderTop';
-import Image from 'next/image';
-import Link from 'next/link';
 import Nav from './Nav';
-import SearchInput from './SearchInput';
-import axios from 'axios';
-import chat from '/public/image/chat.svg';
 import { login } from '@/redux/slice/loginSlice';
-import logo from '/public/image/logo.jpg';
 import { logout } from '@/redux/slice/loginSlice';
-import profile from '/public/image/profile.jpg';
 import { setAddresses } from '@/redux/slice/addressSlice';
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import useRelogin from '@/app/hooks/useRelogin';
 
 export default function Header() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
@@ -26,53 +20,14 @@ export default function Header() {
   const addresses = useSelector((state) => state.address.addresses);
   const access = useSelector((state) => state.login.access);
   const dispatch = useDispatch();
-  const router = useRouter();
   const pathname = usePathname();
-
-  const handleRelogin = useCallback(async () => {
-    const cookies = new Cookies();
-    const refresh = cookies.get('refresh');
-
-    try {
-      const response = await axios.post(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`,
-        { refresh: refresh }
-      );
-
-      const userInfo = {
-        isLoggedIn: true,
-        loginType: response.data.type || 'email',
-        user: {
-          userId: response.data.userId,
-          nickname: response.data.nickname,
-          profileImage: response.data.profileImg,
-          location: response.data.location,
-          isCertified: response.data.isCertified,
-        },
-        access: response.data.access,
-      };
-      localStorage.setItem('loginType', userInfo.loginType);
-      dispatch(
-        login({
-          user: userInfo.user,
-          access: userInfo.access,
-        })
-      );
-    } catch (error) {
-      if (
-        error.response.data.message === '리프레시 토큰이 유효하지 않습니다.'
-      ) {
-        alert('자동로그인이 만료되었습니다. 다시 로그인해 주세요.');
-        cookies.remove('refresh', { path: '/' });
-      }
-    }
-  }, [dispatch]);
+  const relogin = useRelogin();
 
   useEffect(() => {
     if (localStorage.getItem('dutchie-rememberMe') && !access) {
-      handleRelogin();
+      relogin();
     }
-  }, [access, handleRelogin]);
+  }, [access, relogin]);
 
   // tab 간 데이터 동기화
   useEffect(() => {
@@ -118,41 +73,7 @@ export default function Header() {
     <header className="fixed h-[154px] top-0 left-0 right-0 z-10 w-full bg-white shadow">
       <div className=" mx-auto w-[1020px]">
         <HeaderTop />
-        <div className="flex items-center relative w-full">
-          <Link href="/" className="contents w-[160px]">
-            <Image
-              className="w-[160px] h-[96px] mr-[65px] cursor-pointer object-contain"
-              src={logo}
-              alt="logo"
-              width={160}
-              height={96}
-              priority
-            />
-          </Link>
-          <SearchInput />
-
-          {isLoggedIn && (
-            <div className="flex justify-end w-full">
-              <Image
-                className="w-[55px] h-[55px]"
-                alt="chat"
-                width={40}
-                height={40}
-                src={chat}
-              />
-              <div className="relative w-[55px] h-[55px] ml-[18px] cursor-pointer">
-                <Image
-                  className="rounded-full border"
-                  src={user?.profileImage || profile}
-                  alt="profile"
-                  fill
-                  style={{ objectFit: 'cover' }}
-                  onClick={() => router.push('/mypage')}
-                />
-              </div>
-            </div>
-          )}
-        </div>
+        <HeaderMain profileImage={user?.profileImage} />
         <Nav />
       </div>
     </header>

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -59,7 +59,6 @@ export default function Header() {
         })
       );
     } catch (error) {
-      console.log(error);
       if (
         error.response.data.message === '리프레시 토큰이 유효하지 않습니다.'
       ) {

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -2,6 +2,7 @@
 
 import '@/styles/header.css';
 
+import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -15,61 +16,102 @@ import axios from 'axios';
 import chat from '/public/image/chat.svg';
 import { login } from '@/redux/slice/loginSlice';
 import logo from '/public/image/logo.jpg';
+import { logout } from '@/redux/slice/loginSlice';
 import profile from '/public/image/profile.jpg';
 import { setAddresses } from '@/redux/slice/addressSlice';
-import { useEffect } from 'react';
 
 export default function Header() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const user = useSelector((state) => state.login.user);
   const addresses = useSelector((state) => state.address.addresses);
+  const access = useSelector((state) => state.login.access);
   const dispatch = useDispatch();
   const router = useRouter();
   const pathname = usePathname();
 
-  useEffect(() => {
+  const handleRelogin = useCallback(async () => {
     const cookies = new Cookies();
     const refresh = cookies.get('refresh');
-    const handleRelogin = async () => {
-      try {
-        const response = await axios.post(
-          `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`,
-          { refresh: refresh }
-        );
 
-        const userInfo = {
-          isLoggedIn: true,
-          loginType: response.data.type || 'email',
-          user: {
-            userId: response.data.userId,
-            nickname: response.data.nickname,
-            profileImage: response.data.profileImg,
-            location: response.data.location,
-            isCertified: response.data.isCertified,
-          },
-          access: response.data.access,
+    try {
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`,
+        { refresh: refresh }
+      );
+
+      const userInfo = {
+        isLoggedIn: true,
+        loginType: response.data.type || 'email',
+        user: {
+          userId: response.data.userId,
+          nickname: response.data.nickname,
+          profileImage: response.data.profileImg,
+          location: response.data.location,
+          isCertified: response.data.isCertified,
+        },
+        access: response.data.access,
+      };
+      localStorage.setItem('loginType', userInfo.loginType);
+      dispatch(
+        login({
+          user: userInfo.user,
+          access: userInfo.access,
+        })
+      );
+    } catch (error) {
+      console.log(error);
+      if (
+        error.response.data.message === '리프레시 토큰이 유효하지 않습니다.'
+      ) {
+        alert('자동로그인이 만료되었습니다. 다시 로그인해 주세요.');
+        cookies.remove('refresh', { path: '/' });
+      }
+    }
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (localStorage.getItem('dutchie-rememberMe') && !access) {
+      handleRelogin();
+    }
+  }, [access, handleRelogin]);
+
+  useEffect(() => {
+    if (!access && !localStorage.getItem('dutchie-rememberMe')) {
+      localStorage.setItem('storage-change', '1');
+      localStorage.removeItem('storage-change');
+    }
+  }, [access]);
+
+  useEffect(() => {
+    const handleStorageEvent = (e) => {
+      if (!e.newValue) return;
+
+      if (e.key === 'storage-change' && access) {
+        const sharedData = {
+          user,
+          access: access,
         };
-        localStorage.setItem('loginType', userInfo.loginType);
+        localStorage.setItem('sharedUserInfo', JSON.stringify(sharedData));
+        localStorage.removeItem('sharedUserInfo');
+      } else if (e.key === 'sharedUserInfo' && !access) {
+        if (e.oldValue) return;
+        const data = JSON.parse(e.newValue);
         dispatch(
           login({
-            user: userInfo.user,
-            access: userInfo.access,
+            user: data.user,
+            access: data.access,
           })
         );
-      } catch (error) {
-        if (
-          error.response.data.message === '리프레시 토큰이 유효하지 않습니다.'
-        ) {
-          alert('자동로그인이 만료되었습니다. 다시 로그인해 주세요.');
-          cookies.remove('refresh', { path: '/' });
-        }
+      } else if (e.key === 'logout-event' && access) {
+        dispatch(logout());
       }
     };
 
-    if (refresh && !isLoggedIn) {
-      handleRelogin();
-    }
-  }, [dispatch, isLoggedIn]);
+    window.addEventListener('storage', handleStorageEvent);
+    return () => {
+      window.removeEventListener('storage', handleStorageEvent);
+    };
+  }, [dispatch, access, user, isLoggedIn]);
 
   useEffect(() => {
     if (pathname === '/' && !isLoggedIn && addresses) {

--- a/dutchiepay/src/app/_components/_layout/HeaderMain.jsx
+++ b/dutchiepay/src/app/_components/_layout/HeaderMain.jsx
@@ -1,0 +1,55 @@
+'use client';
+
+import '@/styles/globals.css';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import SearchInput from '@/app/_components/_layout/SearchInput';
+import chat from '/public/image/chat.svg';
+import logo from '/public/image/logo.jpg';
+import profile from '/public/image/profile.jpg';
+import { useRouter } from 'next/navigation';
+import { useSelector } from 'react-redux';
+
+export default function HeaderMain({ profileImage }) {
+  const router = useRouter();
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+
+  return (
+    <div className="flex items-center relative w-full">
+      <Link href="/" className="contents w-[160px]">
+        <Image
+          className="w-[160px] h-[96px] mr-[65px] cursor-pointer object-contain"
+          src={logo}
+          alt="logo"
+          width={160}
+          height={96}
+          priority
+        />
+      </Link>
+      <SearchInput />
+
+      {isLoggedIn && (
+        <div className="flex justify-end w-full">
+          <Image
+            className="w-[55px] h-[55px]"
+            alt="chat"
+            width={40}
+            height={40}
+            src={chat}
+          />
+          <div className="relative w-[55px] h-[55px] ml-[18px] cursor-pointer">
+            <Image
+              className="rounded-full border"
+              src={profileImage || profile}
+              alt="profile"
+              fill
+              style={{ objectFit: 'cover' }}
+              onClick={() => router.push('/mypage')}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_components/_layout/Nav.jsx
+++ b/dutchiepay/src/app/_components/_layout/Nav.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import '@/styles/globals.css';
-import '@/styles/commerce.css';
 
 import Link from 'next/link';
 import { MENUS } from '@/app/_util/constants';

--- a/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
@@ -50,6 +50,7 @@ export default function LoginSubmit() {
       };
 
       localStorage.setItem('loginType', response.data.loginType || 'email');
+      if (isRemeberMe) localStorage.setItem('dutchie-rememberMe', '1');
       dispatch(
         login({
           user: userInfo,

--- a/dutchiepay/src/app/hooks/useLogout.jsx
+++ b/dutchiepay/src/app/hooks/useLogout.jsx
@@ -1,14 +1,14 @@
+import Cookies from 'universal-cookie';
+import axios from 'axios';
+import { logout } from '@/redux/slice/loginSlice';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import axios from 'axios';
 import { useRouter } from 'next/navigation';
-import { logout } from '@/redux/slice/loginSlice';
-import Cookies from 'universal-cookie';
 
 const useLogout = (accessToken) => {
   const dispatch = useDispatch();
   const router = useRouter();
-  const cookies = new Cookies();
+
   const handleLogout = useCallback(async () => {
     try {
       await axios.post(
@@ -22,11 +22,15 @@ const useLogout = (accessToken) => {
       );
 
       dispatch(logout());
+      const cookies = new Cookies();
       cookies.remove('refresh', { path: '/' });
       sessionStorage.removeItem('user');
+      localStorage.setItem('logout-event', '1');
+      localStorage.removeItem('logout-event');
+      localStorage.removeItem('dutchie-rememberMe');
       router.push('/');
     } catch (error) {
-      console.error('로그아웃 중 오류 발생:', error);
+      alert('오류가 발생했습니다. 다시 시도해주세요.');
     }
   }, [dispatch, accessToken, router]);
 

--- a/dutchiepay/src/app/hooks/useLogout.jsx
+++ b/dutchiepay/src/app/hooks/useLogout.jsx
@@ -24,10 +24,13 @@ const useLogout = (accessToken) => {
       dispatch(logout());
       const cookies = new Cookies();
       cookies.remove('refresh', { path: '/' });
-      sessionStorage.removeItem('user');
-      localStorage.setItem('logout-event', '1');
-      localStorage.removeItem('logout-event');
       localStorage.removeItem('dutchie-rememberMe');
+      sessionStorage.removeItem('user');
+
+      const channel = new BroadcastChannel('auth-channel');
+      channel.postMessage({ type: 'logout-event' });
+      channel.close();
+
       router.push('/');
     } catch (error) {
       alert('오류가 발생했습니다. 다시 시도해주세요.');

--- a/dutchiepay/src/app/hooks/useRelogin.jsx
+++ b/dutchiepay/src/app/hooks/useRelogin.jsx
@@ -1,0 +1,51 @@
+import Cookies from 'universal-cookie';
+import axios from 'axios';
+import { login } from '@/redux/slice/loginSlice';
+import { useDispatch } from 'react-redux';
+
+export default function useRelogin() {
+  const dispatch = useDispatch();
+
+  const handleRelogin = async () => {
+    const cookies = new Cookies();
+    const refresh = cookies.get('refresh');
+
+    if (!refresh) return;
+
+    try {
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`,
+        { refresh: refresh }
+      );
+
+      const userInfo = {
+        isLoggedIn: true,
+        loginType: response.data.type || 'email',
+        user: {
+          userId: response.data.userId,
+          nickname: response.data.nickname,
+          profileImage: response.data.profileImg,
+          location: response.data.location,
+          isCertified: response.data.isCertified,
+        },
+        access: response.data.access,
+      };
+      localStorage.setItem('loginType', userInfo.loginType);
+      dispatch(
+        login({
+          user: userInfo.user,
+          access: userInfo.access,
+        })
+      );
+    } catch (error) {
+      if (
+        error.response.data.message === '리프레시 토큰이 유효하지 않습니다.'
+      ) {
+        alert('자동로그인이 만료되었습니다. 다시 로그인해 주세요.');
+        cookies.remove('refresh', { path: '/' });
+      }
+    }
+  };
+
+  return handleRelogin;
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/tab-data-sharing -> main

## 변경 사항
1. 같은 브라우저 내에 다른 탭에서 페이지 접근 시 sessionStorage 데이터를 전달
2. 여러 탭 활성화 상태에서 로그아웃 시 로그아웃 storage event를 발생시켜 로그아웃 후 데이터를 덮어쓰지 않도록 수정
3. relogin 발동 조건이 sessionStorage 데이터 전달과 동시에 발생되지 않도록 로그인/로그아웃 시 dutchie-rememberMe를 localStorage에 저장시켜 자동로그인을 설정한 사용자를 구분짓도록 수정

## 테스트 결과
실시간으로 변경되는 데이터라 테스트 결과는 생략하였습니다.
테스트 진행 상황
1. A 탭에서 로그인 후 B 탭으로 더취페이 접속 -> B 탭에 A 탭의 정보가 전달 됨
2. 1번 상황 이후 A 탭에서 로그아웃 -> B탭 로그아웃 처리
3. A 탭에서 자동로그인 후 B 탭으로 더취페이 접속 -> relogin 호출 (현재 relogin API가 수정 중이라 error를 반환합니다.)

## ETC
여러 탭에서 같은 데이터를 사용하지만 본질적으로 같은 데이터가 아닙니다. 추후 sessionStorage에 저장되는 다른 데이터들이 많아진다면 해당 데이터들도 동기화시켜주는 작업을 거쳐야 합니다. (현재도 **delivery 동기화 문제**가 남아있습니다만, delivery 외에 다른 데이터들이 추가되지 않는다면, **delivery를 동기화 시켜주는 변수를 추가**하는 식으로 해결이 가능할 것 같습니다. 다만, 2개 이상이 되면 local에 저장되는 불필요한 trigger들이 많아질 것 같아 일단은 다른 방법도 찾아보고 있습니다.)

새로운 탭에서까지 로그인 상태를 유지해야 하는가 -> 자동로그인 기능이 존재하기 때문에 해당 기능을 구현하지 않으면, 자동로그인을 한 사용자가 다른 탭을 킬 때마다 access가 만료되는 상황이 발생합니다.

Header 코드가 다소 길어져서 리팩토링 진행 예정입니다.
