### PR TITLE
[Feat] 비회원 상품 리스트, 상세페이지 API 호출 구현 및 남은 시간 기준 시간 변경

### DIFF
--- a/dutchiepay/src/app/(routes)/commerce/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/commerce/[id]/page.jsx
@@ -18,17 +18,20 @@ export default function CommerceDetail({ params }) {
   useEffect(() => {
     const fetchProduct = async () => {
       try {
+        const headers = {};
+        if (access) {
+          headers.Authorization = `Bearer ${access}`;
+        }
+
         const response = await axios.get(
           `${process.env.NEXT_PUBLIC_BASE_URL}/commerce?buyId=${id}`,
           {
-            headers: {
-              Authorization: `Bearer ${access}`,
-            },
+            headers,
           }
         );
         setProduct(response.data);
       } catch (error) {
-        console.log(error);
+        alert('오류가 발생했습니다. 다시 시도해주세요.');
       }
     };
 

--- a/dutchiepay/src/app/(routes)/commerce/page.jsx
+++ b/dutchiepay/src/app/(routes)/commerce/page.jsx
@@ -33,13 +33,11 @@ export default function Commerce() {
         <ProductFilter filter={filter} setFilter={setFilter} />
       </div>
       <section className="min-h-[400px] flex flex-wrap gap-[30px] mt-[16px] mb-[60px]">
-        {isLoggedIn && (
-          <ProductList
-            category={category}
-            filter={filter}
-            isEndContain={isEndContain}
-          />
-        )}
+        <ProductList
+          category={category}
+          filter={filter}
+          isEndContain={isEndContain}
+        />
       </section>
     </section>
   );

--- a/dutchiepay/src/app/_components/_commerce/_product/ProductList.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_product/ProductList.jsx
@@ -24,12 +24,15 @@ export default function ProductList({ category, filter, isEndContain }) {
     async (filterType, categoryParam, endParam, cursorParam) => {
       setIsLoading(true);
       try {
+        const headers = {};
+        if (access) {
+          headers.Authorization = `Bearer ${access}`;
+        }
+
         const response = await axios.get(
           `${process.env.NEXT_PUBLIC_BASE_URL}/commerce/list?filter=${filterType}&${categoryParam}end=${endParam}&${cursorParam}limit=16`,
           {
-            headers: {
-              Authorization: `Bearer ${access}`,
-            },
+            headers,
           }
         );
 

--- a/dutchiepay/src/app/_components/_commerce/_productDetail/ProductTitle.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_productDetail/ProductTitle.jsx
@@ -6,7 +6,7 @@ import getCategoryNames from '@/app/_util/getCategoryNames';
 export default function ProductTitle({ product }) {
   return (
     <>
-      <p className="text-xs text-blue--500 font-semibold">
+      <p className="text-sm text-blue--500 font-semibold">
         {getCategoryNames(product?.category)}
       </p>
       <h1 className="font-bold text-xl">{product?.productName}</h1>

--- a/dutchiepay/src/app/_util/getRemainingTime.js
+++ b/dutchiepay/src/app/_util/getRemainingTime.js
@@ -1,6 +1,6 @@
 export default function getRemainingTime(endTime) {
   const now = new Date();
-  const endDate = new Date(`${endTime}T00:00:00Z`);
+  const endDate = new Date(`${endTime}T23:59:59Z`);
   const distance = endDate - now;
 
   if (distance <= 0) {

--- a/dutchiepay/src/app/_util/getStarRates.js
+++ b/dutchiepay/src/app/_util/getStarRates.js
@@ -1,4 +1,4 @@
-export default function getStarRates({ rating }) {
+export default function getStarRates(rating) {
   let starRatesArr = [0, 0, 0, 0, 0];
   let starVerScore = rating;
 


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/nonuser-fetch-data

## 변경 사항
1. 상품 리스트와 상세페이지 API를 회원/비회원 상관없이 호출 가능하도록 변경
2. 상품의 남은 시간을 00시 00분 00초가 아닌 23시 59분 59초로 변경했습니다.
3. 별점 반환 값이 제대로 되지 않는 오류를 수정했습니다.
4. 카테고리 폰트 사이즈 변경

## 테스트 결과
비회원도 정상적으로 데이터 호출됩니다.
![스크린샷 2024-11-03 224608](https://github.com/user-attachments/assets/ebd106bb-720f-46b6-9d50-d26cb65cca35)


## ETC
상품 남은 시간이 년-월-일만 전달되어 00시 00분 00초를 기준으로 구현했으나 상품 리스트와 상세페이지에서 남은 시간을 다르게 표시해 수정했습니다.
