### PR TITLE
[fix] 회원탈퇴 시 로그아웃 API 호출하지 않고 로그인 정보 초기화하도록 변경

### DIFF
--- a/dutchiepay/src/app/(modals)/withdraw-auth/page.jsx
+++ b/dutchiepay/src/app/(modals)/withdraw-auth/page.jsx
@@ -10,7 +10,7 @@ import axios from 'axios';
 import { useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
-export default function AuthPhone() {
+export default function WithdrawAuth() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const access = useSelector((state) => state.login.access);
   const [isPhoneAuth, setIsPhoneAuth] = useState(false); // 핸드폰 인증 요청 여부
@@ -37,7 +37,11 @@ export default function AuthPhone() {
   }, [access, isLoggedIn]);
 
   const handleWithdraw = async () => {
-    if (confirm('정말 탈퇴하실겁니까?')) {
+    if (
+      confirm(
+        '정말 탈퇴하시겠습니까?\n탈퇴한 계정은 복구가 불가능합니다. 신중하게 결정해주세요.'
+      )
+    ) {
       try {
         if (loginType === 'email') {
           await axios.delete(`${process.env.NEXT_PUBLIC_BASE_URL}/users`, {
@@ -55,9 +59,9 @@ export default function AuthPhone() {
             }
           );
         }
-        // 부모 창에 로그아웃 메시지 전송
-        window.opener.postMessage({ type: 'LOGOUT' }, window.location.origin);
+        window.opener.postMessage({ type: 'WITHDRAW' }, window.location.origin);
         alert('정상적으로 탈퇴처리 되었습니다.');
+        closeWindow();
       } catch (error) {
         // 에러 처리
         alert('탈퇴 처리 중 오류가 발생했습니다.');

--- a/dutchiepay/src/app/_components/_commerce/_product/ProductLike.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_product/ProductLike.jsx
@@ -19,15 +19,15 @@ export default function ProductLike({ isLiked, productId }) {
     e.preventDefault(); // Link 동작하지 않도록 함
     e.stopPropagation(); // Link로 전파되지 않도록 함
 
-    /*await axios.patch(
+    await axios.patch(
       `${process.env.NEXT_PUBLIC_BASE_URL}/commerce`,
-      { buyPostId: productId },
+      { buyId: productId },
       {
         headers: {
           Authorization: `Bearer ${access}`,
         },
       }
-    );*/
+    );
 
     setIsProductLiked(!isProductLiked);
   };


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/withdraw-logout -> main

## 변경 사항
1. 회원탈퇴 시 useLogout이 아닌 별도 로그아웃처리를 진행해 로그아웃 API를 호출하지 않도록 변경
2. /auth-phone을 탈퇴용 핸드폰 인증 페이지임을 명확히 할 수 있도록 /withdraw-auth로 변경
3. 인증 완료 후 탈퇴 시 전달되는 message를 로그아웃이 아닌 회원탈퇴임을 명확히 함
4. 상품 좋아요 API 호출되도록 주석 해제

## 테스트 결과

## ETC

