### PR TITLE
[feat] 카카오페이 결제 요청 API 및 결제 상태 message 처리

### DIFF
--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dutchiepay",
       "version": "0.1.0",
       "dependencies": {
+        "@portone/browser-sdk": "^0.0.10",
         "@reduxjs/toolkit": "^2.2.7",
         "axios": "^1.7.5",
         "crypto-js": "^4.2.0",
@@ -4133,6 +4134,11 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/@portone/browser-sdk": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@portone/browser-sdk/-/browser-sdk-0.0.10.tgz",
+      "integrity": "sha512-AylNhel3iWZuq632Axfgg5CLTVgv5xhjxJb0Umfy4chi/PV0K2R5ry/9ywOrKTPdSWqo3KwKVZGgv4X46Gvz+g=="
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
@@ -9188,7 +9194,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9878,8 +9883,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -16629,7 +16633,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -14,6 +14,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@portone/browser-sdk": "^0.0.10",
     "@reduxjs/toolkit": "^2.2.7",
     "axios": "^1.7.5",
     "crypto-js": "^4.2.0",

--- a/dutchiepay/src/app/(routes)/order/page.jsx
+++ b/dutchiepay/src/app/(routes)/order/page.jsx
@@ -90,7 +90,7 @@ export default function Order() {
 
       if (allowedOrigins.includes(event.origin)) {
         if (event.data.type === 'PAYMENT_APPROVED') {
-          router.push(`/success?orderid=${event.data.orderId}`);
+          router.push(`/order/success?orderid=${event.data.orderNum}`);
         } else if (
           event.data.type === 'PAYMENT_APPROVED' ||
           event.data.type === 'PAYMENT_FAIL'

--- a/dutchiepay/src/app/(routes)/order/page.jsx
+++ b/dutchiepay/src/app/(routes)/order/page.jsx
@@ -4,13 +4,14 @@ import '@/styles/globals.css';
 import '@/styles/commerce.css';
 
 import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
+import { DELIVERY_MESSAGE } from '@/app/_util/constants';
 import OrderInfo from '@/app/_components/_commerce/_order/OrderInfo';
 import Orderer from '@/app/_components/_commerce/_order/Orderer';
 import Payment from '@/app/_components/_commerce/_order/Payment';
 import axios from 'axios';
 import { useForm } from 'react-hook-form';
-import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
 export default function Order() {
@@ -20,6 +21,7 @@ export default function Order() {
   const quantity = searchParams.get('quantity');
   const [orderInfo, setOrderInfo] = useState(null);
   const { handleSubmit, register, setValue } = useForm();
+  const router = useRouter();
 
   useEffect(() => {
     const fetchProduct = async () => {
@@ -41,10 +43,69 @@ export default function Order() {
     fetchProduct();
   }, [buyId, quantity, access]);
 
-  const onSubmit = (FormData) => {
-    // 결제 제출 코드 추후 구현 예정
-    console.log(FormData);
+  const openPopup = (redirectUrl) => {
+    window.open(redirectUrl, `더취페이 결제`, 'width=600,height=400');
   };
+
+  const onSubmit = async (formData) => {
+    if (DELIVERY_MESSAGE[formData.deliveryMessage]) {
+      formData.deliveryMessage = DELIVERY_MESSAGE[formData.deliveryMessage];
+    } else if (formData.deliveryMessage === 'option5') {
+      formData.deliveryMessage = formData.customMessage;
+    }
+
+    if (formData.paymentMethod === '카카오페이') {
+      try {
+        const response = await axios.post(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/pay/ready?type=kakao`,
+          {
+            productName: orderInfo.productName,
+            quantity: Number(quantity),
+            totalAmount: orderInfo.salePrice * quantity,
+            taxFreeAmount: 0,
+            receiver: formData.recipient,
+            phone: formData.phone,
+            zipCode: formData.zipCode,
+            address: formData.address,
+            detail: formData.detail,
+            message: formData.deliveryMessage,
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${access}`,
+            },
+          }
+        );
+
+        openPopup(response.data.redirectUrl);
+      } catch (error) {
+        alert('오류가 발생했습니다. 다시 시도해주세요.');
+      }
+    }
+  };
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      const allowedOrigins = [process.env.NEXT_PUBLIC_BASE_URL];
+
+      if (allowedOrigins.includes(event.origin)) {
+        if (event.data.type === 'PAYMENT_APPROVED') {
+          router.push(`/success?orderid=${event.data.orderId}`);
+        } else if (
+          event.data.type === 'PAYMENT_APPROVED' ||
+          event.data.type === 'PAYMENT_FAIL'
+        ) {
+          alert('결제가 실패 또는 취소되었습니다. 다시 결제해주세요.');
+        }
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [router]);
 
   return (
     <section className="min-h-[750px] w-[1020px] mt-[40px] mb-[100px]">
@@ -53,7 +114,7 @@ export default function Order() {
         ※ 공동구매 마감 시간 이전까지 결제가 완료 되어야 성공적으로 구매가
         가능합니다.
       </p>
-      <OrderInfo orderInfo={orderInfo} quantity={quantity} />
+      <OrderInfo orderInfo={orderInfo} quantity={Number(quantity)} />
       <form
         className="mt-[40px] flex justify-between"
         onSubmit={handleSubmit(onSubmit)}
@@ -61,7 +122,11 @@ export default function Order() {
         <div className="w-[600px] flex flex-col gap-[12px]">
           <Orderer register={register} setValue={setValue} />
         </div>
-        <Payment orderInfo={orderInfo} quantity={quantity} />
+        <Payment
+          setValue={setValue}
+          orderInfo={orderInfo}
+          quantity={Number(quantity)}
+        />
       </form>
     </section>
   );

--- a/dutchiepay/src/app/(routes)/order/success/page.jsx
+++ b/dutchiepay/src/app/(routes)/order/success/page.jsx
@@ -1,8 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import success from '../../../../../public/image/success.svg';
+import success from '/public/image/success.svg';
+import { useSearchParams } from 'next/navigation';
 
 export default function Success() {
+  const searchParams = useSearchParams();
+  const orderId = searchParams.get('orderid');
+
   return (
     <section className="h-[750px] w-[1020px] flex justify-center items-center">
       <section className="flex flex-col gap-[16px] justify-center items-center">
@@ -22,7 +26,7 @@ export default function Success() {
         <p className="text-center text-lg">
           고객님이 주문하신 주문번호는
           <br />
-          <strong className="text-red--500">24081612345</strong> 입니다.
+          <strong className="text-red--500">{orderId}</strong> 입니다.
         </p>
         <p className="text-xs text-gray--500">
           주문 내역은 마이페이지의 “구매내역”에서 확인하실 수 있습니다.

--- a/dutchiepay/src/app/(routes)/order/success/page.jsx
+++ b/dutchiepay/src/app/(routes)/order/success/page.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import success from '/public/image/success.svg';

--- a/dutchiepay/src/app/_components/_commerce/_order/Payment.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_order/Payment.jsx
@@ -3,7 +3,7 @@ import '@/styles/globals.css';
 
 import PaymentChoice from './PaymentChoice';
 
-export default function Payment({ orderInfo, quantity }) {
+export default function Payment({ setValue, orderInfo, quantity }) {
   return (
     <article className="w-[380px] flex flex-col gap-[8px]">
       <h2 className="text-2xl font-bold">결제 정보</h2>
@@ -35,7 +35,7 @@ export default function Payment({ orderInfo, quantity }) {
         </div>
       </div>
 
-      <PaymentChoice />
+      <PaymentChoice setValue={setValue} />
 
       <button
         className="w-full mt-[16px] py-[8px] bg-blue--500 text-white text-lg font-semibold rounded-lg"

--- a/dutchiepay/src/app/_components/_commerce/_order/PaymentChoice.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_order/PaymentChoice.jsx
@@ -5,34 +5,57 @@ import '@/styles/globals.css';
 
 import { useState } from 'react';
 
-export default function PaymentChoice() {
+export default function PaymentChoice({ setValue }) {
   const [paymentMethod, setPaymentMethod] = useState('');
+
+  const handlePaymentChange = (method) => {
+    setPaymentMethod(method);
+    setValue('paymentMethod', method);
+  };
 
   return (
     <article className="mt-[8px] flex flex-col gap-[8px]">
       <h3 className="text-lg font-bold">결제 수단 선택</h3>
       <div className="flex justify-between">
-        <button
-          className={`product-order__button ${paymentMethod === '신용카드' && 'product-order__button__active'}`}
-          onClick={() => setPaymentMethod('신용카드')}
-          type="button"
+        <label
+          className={`product-order__button ${paymentMethod === '신용카드' ? 'product-order__button__active' : ''}`}
+          onClick={() => handlePaymentChange('신용카드')}
         >
+          <input
+            className="hidden text-center"
+            type="radio"
+            value="신용카드"
+            checked={paymentMethod === '신용카드'}
+            onChange={() => handlePaymentChange('신용카드')}
+          />
           신용카드
-        </button>
-        <button
-          className={`product-order__button ${paymentMethod === '무통장 입금' && 'product-order__button__active'}`}
-          onClick={() => setPaymentMethod('무통장 입금')}
-          type="button"
+        </label>
+        <label
+          className={`product-order__button ${paymentMethod === '무통장 입금' ? 'product-order__button__active' : ''}`}
+          onClick={() => handlePaymentChange('무통장 입금')}
         >
+          <input
+            className="hidden"
+            type="radio"
+            value="무통장 입금"
+            checked={paymentMethod === '무통장 입금'}
+            onChange={() => handlePaymentChange('무통장 입금')}
+          />
           무통장 입금
-        </button>
-        <button
-          className={`product-order__button ${paymentMethod === '카카오페이' && 'product-order__button__active'}`}
-          onClick={() => setPaymentMethod('카카오페이')}
-          type="button"
+        </label>
+        <label
+          className={`product-order__button ${paymentMethod === '카카오페이' ? 'product-order__button__active' : ''}`}
+          onClick={() => handlePaymentChange('카카오페이')}
         >
+          <input
+            className="hidden text-center"
+            type="radio"
+            value="카카오페이"
+            checked={paymentMethod === '카카오페이'}
+            onChange={() => handlePaymentChange('카카오페이')}
+          />
           카카오페이
-        </button>
+        </label>
       </div>
     </article>
   );

--- a/dutchiepay/src/app/_util/constants.js
+++ b/dutchiepay/src/app/_util/constants.js
@@ -80,3 +80,10 @@ export const MYPAGE_ICON = {
   문의내역: question,
   후기내역: review,
 };
+
+export const DELIVERY_MESSAGE = {
+  option1: '문 앞에 놓아 주시면 돼요.',
+  option2: '직접 받을게요. (부재시 문 앞)',
+  option3: '벨 누르지 말아주세요.',
+  option4: '배송 전에 미리 연락주세요.',
+};

--- a/dutchiepay/src/styles/commerce.css
+++ b/dutchiepay/src/styles/commerce.css
@@ -180,6 +180,7 @@
   padding: 12px;
   font-weight: 500;
   font-size: 14px;
+  text-align: center;
 }
 
 .product-order__button__active {


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/kakao-pay -> main

## 변경 사항
1. 커스텀 배송 메세지 처리 및 배송 메세지 상수화
2. 카카오페이 결제 요청 시 카카오 결제 요청 API 호출
3. 결제 요청 반환 값으로 redirect
4. postMessage를 통해 백엔드로부터 결제 결과 반환 및 성공 시 /success 페이지로 리다이렉트
5. /success 페이지 URL orderid 쿼리 추가
6. quantity가 문자열로 전달되는 오류 해결

## 테스트 결과
현재 해당 API가 동작되지 않아 테스트는 생략하였습니다.

## ETC
백엔드 결제 연동 테스트를 위해 코드 분리 없이 진행했습니다. 추후 컴포넌트 별도로 나눌 예정입니다.
