### PR TITLE
[fix] 수량 입력 시 빈 문자열도 입력 가능하도록 수정

### DIFF
--- a/dutchiepay/src/app/_components/_commerce/_productDetail/OrderButton.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_productDetail/OrderButton.jsx
@@ -17,8 +17,15 @@ export default function OrderButton({ isEnd, productId, quantity }) {
       router.push('/login');
       return;
     }
+
     if (isEnd) {
       e.preventDefault(); // 마감됐을 경우, Link 동작되지 않도록 기본 동작 제거
+    }
+
+    if (quantity === '') {
+      e.preventDefault();
+      alert('수량을 입력해주세요.');
+      return;
     }
   };
 

--- a/dutchiepay/src/app/_components/_commerce/_productDetail/Quantity.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_productDetail/Quantity.jsx
@@ -29,11 +29,17 @@ export default function Quantity({ salePrice, quantity, setQuantity }) {
           type="number"
           value={quantity}
           onChange={(e) => {
-            const newValue = parseInt(e.target.value, 10);
-            if (newValue >= 99) {
-              setQuantity(99);
-            } else if (newValue >= 1) {
-              setQuantity(newValue);
+            const inputValue = e.target.value;
+            if (inputValue === '') {
+              setQuantity('');
+            } else {
+              const newValue = parseInt(inputValue, 10);
+              if (newValue >= 99) {
+                if (newValue > 99) alert('최대 99개까지 구매 가능합니다.');
+                setQuantity(99);
+              } else if (newValue >= 1) {
+                setQuantity(newValue);
+              }
             }
           }}
           min={1}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/quantity-input -> main

## 변경 사항
1. 수량 입력 시 빈 문자열도 입력 가능하도록 수정
2. 수량이 빈 문자열일 경우, 회원이 구매 버튼 클릭 시 alert 표시 (비회원은 로그인 페이지)
3. 수량이 99개를 넘을 경우 alert

## 테스트 결과
![image](https://github.com/user-attachments/assets/728e963a-3fa6-47be-85ce-227e7beb468d)
![image](https://github.com/user-attachments/assets/03038d42-06c1-4832-abc2-fc5c3ed467cd)
![image](https://github.com/user-attachments/assets/c57a86f5-deec-4d9d-bb6c-5cf6716a83ac)

## ETC
