### PR TITLE
[fix] 마감 기한을 KST로 계산하도록 수정

### DIFF
--- a/dutchiepay/src/app/_util/getFormatDate.js
+++ b/dutchiepay/src/app/_util/getFormatDate.js
@@ -27,7 +27,7 @@ const convertToKST = (date) => {
 
 const getRemainingTime = (hasSecond, endTime) => {
   const now = new Date();
-  const endDate = new Date(`${endTime}T23:59:59Z`);
+  const endDate = new Date(`${endTime}T23:59:59+09:00`);
   const distance = endDate - now;
 
   if (distance <= 0) {


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/timezone -> main

## 변경 사항
UTC 형태로 변환되던 마감 기한을 KST 형식으로 지정한 뒤 시간을 계산하도록 수정했습니다.

## 테스트 결과
![image](https://github.com/user-attachments/assets/4b81b00f-3208-4487-983e-d79a7d84aad4)

## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
