### PR TITLE
[fix] BroadcastChannel 및 relogin layout에서 실행되도록 수정

### DIFF
--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -2,77 +2,16 @@
 
 import '@/styles/header.css';
 
-import { useDispatch, useSelector } from 'react-redux';
-
 import HeaderMain from './HeaderMain';
 import HeaderTop from './HeaderTop';
 import Nav from './Nav';
-import { login } from '@/redux/slice/loginSlice';
-import { logout } from '@/redux/slice/loginSlice';
-import { setAddresses } from '@/redux/slice/addressSlice';
-import { useEffect } from 'react';
-import useRelogin from '@/app/hooks/useRelogin';
 
 export default function Header() {
-  const user = useSelector((state) => state.login.user);
-  const access = useSelector((state) => state.login.access);
-  const dispatch = useDispatch();
-  const relogin = useRelogin();
-
-  useEffect(() => {
-    if (localStorage.getItem('dutchie-rememberMe') && !access) {
-      relogin();
-    }
-  }, [access, relogin]);
-
-  // tab 간 데이터 동기화
-  useEffect(() => {
-    const channel = new BroadcastChannel('auth-channel');
-
-    if (!access && !localStorage.getItem('dutchie-rememberMe')) {
-      channel.postMessage({ type: 'sync-request' });
-    }
-
-    channel.onmessage = (e) => {
-      const { type, data } = e.data;
-
-      if (type === 'sync-request' && access) {
-        const sharedData = {
-          user,
-          access: access,
-        };
-        channel.postMessage({ type: 'sync-data', data: sharedData });
-      } else if (type === 'sync-data' && !access) {
-        dispatch(
-          login({
-            user: data.user,
-            access: data.access,
-          })
-        );
-      } else if (type === 'logout-event' && access) {
-        dispatch(logout());
-      } else if (type === 'login-event') {
-        dispatch(
-          login({
-            user: data.user,
-            access: data.access,
-          })
-        );
-      } else if (type === 'change-address') {
-        dispatch(setAddresses(data));
-      }
-    };
-
-    return () => {
-      channel.close();
-    };
-  }, [dispatch, access, user]);
-
   return (
     <header className="fixed h-[154px] top-0 left-0 right-0 z-20 w-full bg-white shadow">
       <div className=" mx-auto w-[1020px]">
         <HeaderTop />
-        <HeaderMain profileImage={user?.profileImage} />
+        <HeaderMain />
         <Nav />
       </div>
     </header>

--- a/dutchiepay/src/app/_components/_layout/HeaderMain.jsx
+++ b/dutchiepay/src/app/_components/_layout/HeaderMain.jsx
@@ -11,9 +11,10 @@ import profile from '/public/image/profile.jpg';
 import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
-export default function HeaderMain({ profileImage }) {
+export default function HeaderMain() {
   const router = useRouter();
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const profileImage = useSelector((state) => state.login.user.profileImage);
 
   return (
     <div className="flex items-center relative w-full">
@@ -40,11 +41,10 @@ export default function HeaderMain({ profileImage }) {
           />
           <div className="relative w-[55px] h-[55px] ml-[18px] cursor-pointer">
             <Image
-              className="rounded-full border"
+              className="rounded-full border object-cover"
               src={profileImage || profile}
               alt="profile"
               fill
-              style={{ objectFit: 'cover' }}
               onClick={() => router.push('/mypage')}
             />
           </div>


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/userinfo-tab-sharing -> main

## 변경 사항
1. 탭간 정보 공유와 재로그인 코드를 layout에서 실행하여 다른 페이지 및 팝업에서도 유저정보를 가질 수 있도록 변경

## 테스트 결과
팝업에서 수정/추가 등 작업 정상적으로 가능

## ETC
가끔씩 main 페이지에서 오류가 발생했습니다가 뜨는 경우가 있는데 main 내의 fetch 문제인 걸로 확인됐으나 서버 문제는 아니고 일시적인 문제거나 프론트 문제일 것 같습니다. 현재는 해당 오류가 발생하지 않지만, 혹여나 main에서 오류 발생할 경우 알려주세요
