### PR TITLE
[fix] 환불 요청 시 refresh 되지 않는 오류 해결

### DIFF
--- a/dutchiepay/src/app/_components/_commerce/_refund/RefundForm.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_refund/RefundForm.jsx
@@ -43,6 +43,8 @@ export default function RefundForm({ orderId }) {
           }
         );
 
+        alert('정상적으로 처리되었습니다.');
+
         window.opener.postMessage(
           { type: 'REFUND/EXCHANGE' },
           window.location.origin

--- a/dutchiepay/src/app/_util/constants.js
+++ b/dutchiepay/src/app/_util/constants.js
@@ -76,20 +76,30 @@ export const ORDER_STATUS = {
   주문취소: '배송전',
   교환처리: '배송완료',
 };
+
 export const MART_CATEGORIES = {
   전체: '',
   마트구매: 'mart',
   같이배달: 'delivery',
 };
+
 export const USED_CATEGORIES = {
   전체: '',
   중고판매: 'trade',
   중고나눔: 'share',
 };
+
 export const COMMUNITY_CATEGORIES = {
   전체: '',
   정보공유: 'info',
   질문: 'qna',
   취미생활: 'hobby',
   자유게시판: 'free',
+};
+
+export const ORDER_FILTER = {
+  배송전: 'pending',
+  배송중: 'shipped',
+  배송완료: 'delivered',
+  전체: null,
 };


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/exchange-refresh -> main

## 변경 사항
1. 환불/교환 요청 시 refresh가 되도록 hasFetched.current = false; 설정
2. 환불/교환 요청 시 refresh를 할 경우 페이지를 1로 호출

## 테스트 결과
정상적으로 refresh 됩니다. (환불 가능한 상품이 더 없어서 이미지는 생략합니다.)

## ETC
loadmore 코드가 page를 1씩 증가하는 코드이다보니 페이지가 1일 때는 제외하고는 같은 페이지를 호출해도 order 배열에 추가해버리게 됩니다. 그럴 경우 refresh를 하게 되면 해당 부분 구매 내역이 중복이 되기 때문에 로직을 완전히 수정하기에는 시간 문제가 있을 것 같아서 페이지 1 (초기화) 하는 방식으로 작업했습니다. 환불 요청 시 바로 팝업창이 닫기면서 수정되기 때문에 조금 더 자연스럽게 하기 위해 alert로 정상 처리 됐음을 알리는 과정을 추가했습니다
