### PR TITLE
[Fix] 상품 목록에서 좋아요를 누를 경우 필터링을 바꾸면 해당 위치 상품이 isLiked와 상관없이 좋아요 표시되는 오류

### DIFF
--- a/dutchiepay/src/app/_components/_commerce/ProductLike.jsx
+++ b/dutchiepay/src/app/_components/_commerce/ProductLike.jsx
@@ -9,9 +9,9 @@ import Image from 'next/image';
 import axios from 'axios';
 import fullheart from '/public/image/fullheart.svg';
 import heart from '/public/image/heart.svg';
+import useReissueToken from '@/app/hooks/useReissueToken';
 import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
-import useReissueToken from '@/app/hooks/useReissueToken';
 
 export default function ProductLike({ isLiked, productId, size }) {
   const access = useSelector((state) => state.login.access);
@@ -22,7 +22,7 @@ export default function ProductLike({ isLiked, productId, size }) {
 
   useEffect(() => {
     setIsProductLiked(isLiked);
-  }, [isLiked]);
+  }, [isLiked, productId]);
 
   const handleIsLiked = async (e) => {
     e.preventDefault(); // Link 동작하지 않도록 함

--- a/dutchiepay/src/app/_components/_commerce/_refund/RefundForm.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_refund/RefundForm.jsx
@@ -43,6 +43,8 @@ export default function RefundForm({ orderId }) {
           }
         );
 
+        alert('정상적으로 처리되었습니다.');
+
         window.opener.postMessage(
           { type: 'REFUND/EXCHANGE' },
           window.location.origin

--- a/dutchiepay/src/app/_util/constants.js
+++ b/dutchiepay/src/app/_util/constants.js
@@ -76,20 +76,30 @@ export const ORDER_STATUS = {
   주문취소: '배송전',
   교환처리: '배송완료',
 };
+
 export const MART_CATEGORIES = {
   전체: '',
   마트구매: 'mart',
   같이배달: 'delivery',
 };
+
 export const USED_CATEGORIES = {
   전체: '',
   중고판매: 'trade',
   중고나눔: 'share',
 };
+
 export const COMMUNITY_CATEGORIES = {
   전체: '',
   정보공유: 'info',
   질문: 'qna',
   취미생활: 'hobby',
   자유게시판: 'free',
+};
+
+export const ORDER_FILTER = {
+  배송전: 'pending',
+  배송중: 'shipped',
+  배송완료: 'delivered',
+  전체: null,
 };


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/like-rendering -> main

## 변경 사항
productId가 변경될 때마다 isLiked 여부를 다시 체크하도록 수정했습니다.

## 테스트 결과
좋아요 상품 모두 reset 한 상태
![스크린샷 2024-11-27 124643](https://github.com/user-attachments/assets/638bc46b-c26f-4813-8b9d-6359d47227a9)
해당 상품 좋아요를 누르고 필터 변경 후, 좋아요 누른 상품에만 좋아요 표시되고 기존에 좋아요한 위치에는 표시되지 않음
![스크린샷 2024-11-27 124648](https://github.com/user-attachments/assets/06b95afd-055a-4524-a348-e46c1140c34d)

## ETC
