### PR TITLE
[fix] PostDetail sticky로 고정

### DIFF
--- a/dutchiepay/src/app/(routes)/community/detail/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/detail/page.jsx
@@ -11,31 +11,37 @@ export default function CommunityDetail() {
   const postId = searchParams.get('postId');
 
   return (
-    <section className="min-h-[750px] w-[1020px] w-full flex">
-      <PostContent category={'정보'} menu={'커뮤니티'} isMyPostWritten={true} />
+    <section className="min-h-[750px] w-[1020px]">
+      <div className="flex justify-between">
+        <PostContent
+          category={'정보'}
+          menu={'커뮤니티'}
+          isMyPostWritten={true}
+        />
 
-      <section className="w-[290px] h-[750px] fixed top-[158px] right-[440px] pl-[24px] py-[40px] flex flex-col gap-[40px]">
-        <article>
-          <h2 className="text-2xl font-bold">유사한 게시글</h2>
-          <div className="flex flex-col gap-[12px] mt-[8px]">
-            <Post_Similar />
-            <Post_Similar />
-            <Post_Similar />
-            <Post_Similar />
-            <Post_Similar />
-          </div>
-        </article>
-        <article>
-          <h2 className="text-2xl font-bold">주간 HOT🔥 게시글</h2>
-          <div className="flex flex-col gap-[12px] mt-[8px]">
-            <Post_Hot index={1} />
-            <Post_Hot index={2} />
-            <Post_Hot index={3} />
-            <Post_Hot index={4} />
-            <Post_Hot index={5} />
-          </div>
-        </article>
-      </section>
+        <section className="w-[290px] h-[750px] sticky top-[150px] pl-[24px] py-[40px] flex flex-col gap-[40px]">
+          <article>
+            <h2 className="text-2xl font-bold">유사한 게시글</h2>
+            <div className="flex flex-col gap-[12px] mt-[8px]">
+              <Post_Similar />
+              <Post_Similar />
+              <Post_Similar />
+              <Post_Similar />
+              <Post_Similar />
+            </div>
+          </article>
+          <article>
+            <h2 className="text-2xl font-bold">주간 HOT🔥 게시글</h2>
+            <div className="flex flex-col gap-[12px] mt-[8px]">
+              <Post_Hot index={1} />
+              <Post_Hot index={2} />
+              <Post_Hot index={3} />
+              <Post_Hot index={4} />
+              <Post_Hot index={5} />
+            </div>
+          </article>
+        </section>
+      </div>
     </section>
   );
 }

--- a/dutchiepay/src/app/(routes)/mart/detail/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/detail/page.jsx
@@ -10,13 +10,15 @@ export default function MartDetail() {
   const postId = searchParams.get('postId');
 
   return (
-    <section className="min-h-[750px] w-[1020px] w-full flex">
-      <PostContent
-        category={'배달'}
-        menu={'마트/배달'}
-        isMyPostWritten={true}
-      />
-      <PostDetail menu={'마트/배달'} isMyPostWritten={true} />
+    <section className="min-h-[750px] w-[1020px]">
+      <div className="flex justify-between">
+        <PostContent
+          category={'배달'}
+          menu={'마트/배달'}
+          isMyPostWritten={true}
+        />
+        <PostDetail menu={'마트/배달'} isMyPostWritten={true} />
+      </div>
     </section>
   );
 }

--- a/dutchiepay/src/app/(routes)/used/detail/page.jsx
+++ b/dutchiepay/src/app/(routes)/used/detail/page.jsx
@@ -10,13 +10,15 @@ export default function UsedDetail({ params }) {
   const postId = searchParams.get('postId');
 
   return (
-    <section className="w-full flex min-h-[750px] w-[1020px]">
-      <PostContent
-        category={'거래'}
-        menu={'거래/나눔'}
-        isMyPostWritten={true}
-      />
-      <PostDetail menu={'거래/나눔'} isTrade={true} isMyPostWritten={true} />
+    <section className="flex min-h-[750px] w-[1020px]">
+      <div className="flex justify-between">
+        <PostContent
+          category={'거래'}
+          menu={'거래/나눔'}
+          isMyPostWritten={true}
+        />
+        <PostDetail menu={'거래/나눔'} isTrade={true} isMyPostWritten={true} />
+      </div>
     </section>
   );
 }

--- a/dutchiepay/src/app/_components/_community/PostDetail.jsx
+++ b/dutchiepay/src/app/_components/_community/PostDetail.jsx
@@ -11,8 +11,8 @@ import selectArrow from '../../../../public/image/selectArrow.svg';
 
 export default function PostDetail({ menu, isTrade = false, isMyPostWritten }) {
   return (
-    <section
-      className="w-[290px] h-[750px] fixed top-[158px] right-[440px] pl-[24px] py-[40px]"
+    <article
+      className="w-[290px] h-[750px] sticky top-[150px] pl-[20px] py-[40px]"
       aria-labelledby="trade-info"
     >
       <div className="flex items-center gap-[8px]">
@@ -92,6 +92,6 @@ export default function PostDetail({ menu, isTrade = false, isMyPostWritten }) {
       <button className="w-full rounded-lg py-[12px] text-white font-bold bg-blue--500">
         채팅방으로 이동
       </button>
-    </section>
+    </article>
   );
 }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 디자인

## 반영 브랜치
fix/mart-post -> main

## 변경 사항
postDetail을 fixed에서 sticky로 변경하고 post 레이아웃을 flex 효과를 추가해 해상도 변경 시에도 PostDetail을 고정시키고 스크롤 시에도 해당 영역이 항상 보일 수 있도록 수정했습니다.

## 테스트 결과
해상도를 줄여도 postDetail 고정
![image](https://github.com/user-attachments/assets/5435229d-229e-4cd3-b36c-4e86e1f307b0)
content 길이가 무한히 길어져도 우측 영역은 항상 보이도록 설정
![image](https://github.com/user-attachments/assets/b2378409-b7f4-4525-be80-4653b28f4a36)

## ETC
이와 유사한 방식으로 sidebar도 해결될 수 있을 것으로 보여 추후 수정 진행하겠습니다
