### PR TITLE
[Feat] 게시글 작성 form 구현 및 react quill 에디터 기능 추가

### DIFF
--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -23,6 +23,7 @@
         "quill": "^1.3.6",
         "quill-image-resize": "^3.0.9",
         "quill-image-resize-module": "^3.0.0",
+        "quill-image-resize-module--fix-imports-error": "^3.0.0",
         "react": "^18",
         "react-content-loader": "^7.0.2",
         "react-daum-postcode": "^3.1.3",
@@ -21094,6 +21095,4962 @@
         "quill": "^1.2.2",
         "raw-loader": "^0.5.1"
       }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quill-image-resize-module--fix-imports-error/-/quill-image-resize-module--fix-imports-error-3.0.0.tgz",
+      "integrity": "sha512-D4jFjVscUqNUlW9SRY+4vynGIgkg/WB0159quuYL1smLmV35tU0DmIXCIVViUiH/umxRlRYYpESrv8bYz2UJbg==",
+      "hasShrinkwrap": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "quill": "^1.2.2",
+        "raw-loader": "^0.5.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/acorn": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.2.tgz",
+      "integrity": "sha1-3ByPuQf2TbKrVz3iMmtzUnwk3jY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/acorn-dynamic-import": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+      "extraneous": true,
+      "dependencies": {
+        "acorn": "^4.0.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/acorn-dynamic-import/node_modules/acorn": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+      "integrity": "sha1-7c2jvZN+dVZBDULtWGD2c5nHlMA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "extraneous": true,
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ajv": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+      "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
+      "extraneous": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "extraneous": true,
+      "dependencies": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/anymatch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "extraneous": true,
+      "dependencies": {
+        "arrify": "^1.0.0",
+        "micromatch": "^2.1.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "extraneous": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/aria-query": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.3.0.tgz",
+      "integrity": "sha1-y4qZhOKGJxHIPICt5bj1yg3itGc=",
+      "extraneous": true,
+      "dependencies": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "extraneous": true,
+      "dependencies": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/arr-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "extraneous": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/array.prototype.find": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "extraneous": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/asn1.js": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "extraneous": true,
+      "dependencies": {
+        "util": "0.10.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
+      "integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
+      "extraneous": true,
+      "dependencies": {
+        "lodash": "^4.14.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-cli": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.0.tgz",
+      "integrity": "sha1-oF/9IQ3KDCiKJtUxnFrIZpomWtA=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-core": "^6.24.0",
+        "babel-polyfill": "^6.23.0",
+        "babel-register": "^6.24.0",
+        "babel-runtime": "^6.22.0",
+        "chokidar": "^1.6.1",
+        "commander": "^2.8.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.2.0",
+        "output-file-sync": "^1.1.0",
+        "path-is-absolute": "^1.0.0",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0",
+        "v8flags": "^2.0.10"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-code-frame": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "extraneous": true,
+      "dependencies": {
+        "chalk": "^1.1.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-core": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.0.tgz",
+      "integrity": "sha1-jzagp39cFVrtb5ILhE0julZ0KgI=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-code-frame": "^6.22.0",
+        "babel-generator": "^6.24.0",
+        "babel-helpers": "^6.23.0",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.24.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.11.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^2.1.1",
+        "json5": "^0.5.0",
+        "lodash": "^4.2.0",
+        "minimatch": "^3.0.2",
+        "path-is-absolute": "^1.0.0",
+        "private": "^0.1.6",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-eslint": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.1.tgz",
+      "integrity": "sha1-B5Qi63O6gR48oIZc6Hrykyf4xS8=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.16.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-generator": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.0.tgz",
+      "integrity": "sha1-66JwqMxM5uCaYb5DRl18YsH4fFY=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.23.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz",
+      "integrity": "sha1-Kd9WvhRNgb3qwIJiv6QdLF6Rzc0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-explode-assignable-expression": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-call-delegate": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
+      "integrity": "sha1-EZkhtWEg8X6drj90tPXMe8wbN+8=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-hoist-variables": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-define-map": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz",
+      "integrity": "sha1-FET5YMlpHWmiztaiBTFfj9AIBOc=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.23.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-explode-assignable-expression": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz",
+      "integrity": "sha1-yXv3bu0+C65ASBIfK52uGk59BHg=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-function-name": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
+      "integrity": "sha1-JXQtZxdciQPb5LbLnZ4fy43PI6Y=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-get-function-arity": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-traverse": "^6.23.0",
+        "babel-types": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-get-function-arity": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
+      "integrity": "sha1-C+tGStadxzR0EKxq3p8DpQY09c4=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-hoist-variables": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
+      "integrity": "sha1-Pqy/cx2AcFhF3S6XGPYAz7m0unI=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-optimise-call-expression": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz",
+      "integrity": "sha1-8+5+7TVbQoITizPQK3g2nkcGIvU=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-regex": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+      "integrity": "sha1-efUyvhZHsfDuNHS19cPaWAAdJH0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-remap-async-to-generator": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.22.0.tgz",
+      "integrity": "sha1-IYaucyeO0DuLFc7QiWCdqYEFM4M=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.22.0",
+        "babel-traverse": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helper-replace-supers": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz",
+      "integrity": "sha1-7q+K2bWOxDN8qUIjus3KH42bS/0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-optimise-call-expression": "^6.23.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-traverse": "^6.23.0",
+        "babel-types": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-helpers": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.23.0.tgz",
+      "integrity": "sha1-T48uCS0LaogIpL3nnCfx4uzw2ZI=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-loader": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
+      "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
+      "extraneous": true,
+      "dependencies": {
+        "find-cache-dir": "^0.1.1",
+        "loader-utils": "^0.2.16",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-async-to-generator": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz",
+      "integrity": "sha1-GUtpOOwZWtNu/EwzqXGs8A2M014=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-remap-async-to-generator": "^6.22.0",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-class-properties": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.23.0.tgz",
+      "integrity": "sha1-GHt0fuQEOZATVjyZPbA480dUrDs=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.23.0",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz",
+      "integrity": "sha1-5IiVzws3W+FIzXyIebQicHoFO1E=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-traverse": "^6.23.0",
+        "babel-types": "^6.23.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-classes": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz",
+      "integrity": "sha1-SbU/MmICov0bO7ql4u3YpPeGQ8E=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-define-map": "^6.23.0",
+        "babel-helper-function-name": "^6.23.0",
+        "babel-helper-optimise-call-expression": "^6.23.0",
+        "babel-helper-replace-supers": "^6.23.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-traverse": "^6.23.0",
+        "babel-types": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
+      "integrity": "sha1-fDg+lim7pIIMEbBCW91ikPfwV+c=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
+      "integrity": "sha1-ZyOXAxwhYQ1y3Su7C6n7Ynfhw2s=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-function-name": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
+      "integrity": "sha1-9fzIsJCT+aI8dqw9njksPsS3cQQ=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-function-name": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.0.tgz",
+      "integrity": "sha1-oZEfubfsfgWkOmPFmVAHVXvPai4=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz",
+      "integrity": "sha1-6SGu+3LCzCbLA9EHYmFWQTIiE08=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-plugin-transform-strict-mode": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-types": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.23.0.tgz",
+      "integrity": "sha1-rjRpIn/6w5sDENkP7HO/3E9jF7A=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-hoist-variables": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.0.tgz",
+      "integrity": "sha1-/V+mNSHK6NJzknw5WK/XwGdzNFA=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-object-super": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
+      "integrity": "sha1-2qYOEUoELqdp3VP+Uo/IIxHrmPw=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-replace-supers": "^6.22.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-parameters": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz",
+      "integrity": "sha1-OiqrtwyK+UXVzjhvGkJQYlqDrjs=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-call-delegate": "^6.22.0",
+        "babel-helper-get-function-arity": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.23.0",
+        "babel-traverse": "^6.23.0",
+        "babel-types": "^6.23.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
+      "integrity": "sha1-i6d24K/6pgv/IekhQDuKZSov9yM=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
+      "integrity": "sha1-qzFoKehm7j9LnrlpOXV9GaW8RZM=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-regex": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
+      "integrity": "sha1-jZzCfn7h3s/mVFT7mGRSoEphPSA=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-regex": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-exponentiation-operator": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.22.0.tgz",
+      "integrity": "sha1-1XyDNSgZGOVO8FMRjObrEIRoCE0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.22.0",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-regenerator": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
+      "integrity": "sha1-ZXQFk6MZxEUiFXU41pC4QJRhfqY=",
+      "extraneous": true,
+      "dependencies": {
+        "regenerator-transform": "0.9.8"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-plugin-transform-strict-mode": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
+      "integrity": "sha1-4AjfATQP3IfpWdplmRt+BZcMjHw=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-polyfill": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.10.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-preset-env": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.3.2.tgz",
+      "integrity": "sha1-COq9K/gQw2eAaffgUjI0GfFEh0k=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^1.4.0",
+        "invariant": "^2.2.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-preset-es2015": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.0.tgz",
+      "integrity": "sha1-wWLWixkyaW4DbNMRDcHM0wPSZzo=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.22.0",
+        "babel-plugin-transform-es2015-classes": "^6.22.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.22.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-register": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.0.tgz",
+      "integrity": "sha1-Xon4RjuplwNW0C6wfavjMIsIDP0=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-core": "^6.24.0",
+        "babel-runtime": "^6.22.0",
+        "core-js": "^2.4.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "extraneous": true,
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.10.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-template": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+      "integrity": "sha1-BNTycK27OqcEqBQ64m+qUpI45jg=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.23.0",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.11.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-traverse": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+      "integrity": "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-code-frame": "^6.22.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.15.0",
+        "debug": "^2.2.0",
+        "globals": "^9.0.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babel-types": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+      "integrity": "sha1-uxcXnXU4utOM0MnhFdNA935+ms8=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/babylon": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
+      "integrity": "sha1-MMWiL0gZeKnn+M399JaxHZS0BNM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/base64-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/big.js": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+      "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/binary-extensions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/brace-expansion": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+      "extraneous": true,
+      "dependencies": {
+        "balanced-match": "^0.4.1",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "extraneous": true,
+      "dependencies": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserify-aes": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+      "extraneous": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "extraneous": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "extraneous": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "extraneous": true,
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/browserslist": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "extraneous": true,
+      "dependencies": {
+        "caniuse-db": "^1.0.30000639",
+        "electron-to-chromium": "^1.2.7"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "extraneous": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "extraneous": true,
+      "dependencies": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/caniuse-db": {
+      "version": "1.0.30000646",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000646.tgz",
+      "integrity": "sha1-xyS5DWHfJChuAV/FKNBiBzwA3vQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "extraneous": true,
+      "dependencies": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/chokidar": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+      "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
+      "extraneous": true,
+      "dependencies": {
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/cipher-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/circular-json": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "extraneous": true,
+      "dependencies": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/cli-width": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "extraneous": true,
+      "dependencies": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "extraneous": true,
+      "dependencies": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/core-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/create-hash": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+      "integrity": "sha1-USEAYte7dHn2xlu0GpIgix1hq60=",
+      "extraneous": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/create-hmac": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+      "integrity": "sha1-0/tLolPriz9W456i+8uK90e9MXA=",
+      "extraneous": true,
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/crypto-browserify": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+      "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
+      "extraneous": true,
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "extraneous": true,
+      "dependencies": {
+        "es5-ext": "^0.10.9"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/debug": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+      "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
+      "extraneous": true,
+      "dependencies": {
+        "ms": "0.7.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "extraneous": true,
+      "dependencies": {
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "extraneous": true,
+      "dependencies": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "extraneous": true,
+      "dependencies": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/doctrine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "extraneous": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/electron-to-chromium": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.2.tgz",
+      "integrity": "sha1-uM5ck7MI2w6S9tBDXEbd7I9jY6s=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/emoji-regex": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.4.1.tgz",
+      "integrity": "sha1-d0hv6c1FQh0mCmI4uI1yHi+tIFA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/enhanced-resolve": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
+      "integrity": "sha1-n0tib1dyRe3PSyrYPYbhf09CHew=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "extraneous": true,
+      "dependencies": {
+        "prr": "~0.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "extraneous": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es-abstract": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "extraneous": true,
+      "dependencies": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.0",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "extraneous": true,
+      "dependencies": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es5-ext": {
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+      "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
+      "extraneous": true,
+      "dependencies": {
+        "es6-iterator": "2",
+        "es6-symbol": "~3.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "extraneous": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-symbol": "^3.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "extraneous": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "extraneous": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "extraneous": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "extraneous": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "extraneous": true,
+      "dependencies": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-config-airbnb": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-14.1.0.tgz",
+      "integrity": "sha1-NV0pAEC7+OAL+LSxn0twy+fCMX8=",
+      "extraneous": true,
+      "dependencies": {
+        "eslint-config-airbnb-base": "^11.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-config-airbnb-base": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.2.tgz",
+      "integrity": "sha1-JZIJp2eL9pPjHL6PlT8ga2qnzMM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-import-resolver-node": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+      "extraneous": true,
+      "dependencies": {
+        "debug": "^2.2.0",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-module-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
+      "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
+      "extraneous": true,
+      "dependencies": {
+        "debug": "2.2.0",
+        "pkg-dir": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "extraneous": true,
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-module-utils/node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-plugin-import": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
+      "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
+      "extraneous": true,
+      "dependencies": {
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.2.0",
+        "eslint-module-utils": "^2.0.0",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "pkg-up": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "extraneous": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-plugin-jsx-a11y": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz",
+      "integrity": "sha1-d5uw/nsI2lZKQiYkkR3hAGHgSO4=",
+      "extraneous": true,
+      "dependencies": {
+        "aria-query": "^0.3.0",
+        "ast-types-flow": "0.0.7",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^1.0.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-plugin-react": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "extraneous": true,
+      "dependencies": {
+        "array.prototype.find": "^2.0.1",
+        "doctrine": "^1.2.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.3.4",
+        "object.assign": "^4.0.4"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "extraneous": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eslint/node_modules/user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "extraneous": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/espree": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.1.tgz",
+      "integrity": "sha1-KKg6tKrtce2P4PXv5ht2oFwTxNI=",
+      "extraneous": true,
+      "dependencies": {
+        "acorn": "^5.0.1",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "extraneous": true,
+      "dependencies": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/esrecurse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "extraneous": true,
+      "dependencies": {
+        "estraverse": "~4.1.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/esrecurse/node_modules/estraverse": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+      "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "extraneous": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/evp_bytestokey": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+      "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
+      "extraneous": true,
+      "dependencies": {
+        "create-hash": "^1.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "extraneous": true,
+      "dependencies": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "extraneous": true,
+      "dependencies": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "extraneous": true,
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fast-diff": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.1.tgz",
+      "integrity": "sha1-CuoOTmBbaiGJ8Ok21Lf7rxt8/Zs="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "extraneous": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "extraneous": true,
+      "dependencies": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/filename-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "extraneous": true,
+      "dependencies": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/find-cache-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+      "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+      "extraneous": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pkg-dir": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "extraneous": true,
+      "dependencies": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/flat-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "extraneous": true,
+      "dependencies": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "extraneous": true,
+      "dependencies": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fs-readdir-recursive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
+      "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.29"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/abbrev": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/aproba": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/are-we-there-yet": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+      "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+      "extraneous": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.0 || ^1.1.13"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "extraneous": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "extraneous": true,
+      "dependencies": {
+        "hoek": "2.x.x"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/brace-expansion": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+      "extraneous": true,
+      "dependencies": {
+        "balanced-match": "^0.4.1",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "extraneous": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "extraneous": true,
+      "dependencies": {
+        "boom": "2.x.x"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "extraneous": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/dashdash/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "extraneous": true,
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/deep-extend": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+      "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "extraneous": true,
+      "dependencies": {
+        "jsbn": "~0.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/form-data": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+      "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
+      "extraneous": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/fstream": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+      "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "extraneous": true,
+      "dependencies": {
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/gauge": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+      "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
+      "extraneous": true,
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "extraneous": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/getpass": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+      "extraneous": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/getpass/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "extraneous": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "extraneous": true,
+      "dependencies": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "extraneous": true,
+      "dependencies": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "extraneous": true,
+      "dependencies": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "extraneous": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "extraneous": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/is-my-json-valid": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+      "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+      "extraneous": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/jodid25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+      "extraneous": true,
+      "dependencies": {
+        "jsbn": "~0.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/jsprim": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+      "extraneous": true,
+      "dependencies": {
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/mime-db": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+      "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/mime-types": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+      "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
+      "extraneous": true,
+      "dependencies": {
+        "mime-db": "~1.26.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+      "extraneous": true,
+      "dependencies": {
+        "brace-expansion": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "extraneous": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/node-pre-gyp": {
+      "version": "0.6.33",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
+      "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
+      "extraneous": true,
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "npmlog": "^4.0.1",
+        "rc": "~1.1.6",
+        "request": "^2.79.0",
+        "rimraf": "~2.5.4",
+        "semver": "~5.3.0",
+        "tar": "~2.2.1",
+        "tar-pack": "~3.3.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "extraneous": true,
+      "dependencies": {
+        "abbrev": "1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/npmlog": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+      "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
+      "extraneous": true,
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.1",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "extraneous": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "extraneous": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/qs": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
+      "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/rc": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+      "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+      "extraneous": true,
+      "dependencies": {
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/rc/node_modules/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/readable-stream": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+      "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
+      "extraneous": true,
+      "dependencies": {
+        "buffer-shims": "^1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "extraneous": true,
+      "dependencies": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1",
+        "uuid": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/rimraf": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+      "extraneous": true,
+      "dependencies": {
+        "glob": "^7.0.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "extraneous": true,
+      "dependencies": {
+        "hoek": "2.x.x"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/sshpk": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+      "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
+      "extraneous": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jodid25519": "^1.0.0",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/sshpk/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "extraneous": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "extraneous": true,
+      "dependencies": {
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tar-pack": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+      "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+      "extraneous": true,
+      "dependencies": {
+        "debug": "~2.2.0",
+        "fstream": "~1.0.10",
+        "fstream-ignore": "~1.0.5",
+        "once": "~1.3.3",
+        "readable-stream": "~2.1.4",
+        "rimraf": "~2.5.1",
+        "tar": "~2.2.1",
+        "uid-number": "~0.0.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tar-pack/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "extraneous": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tar-pack/node_modules/readable-stream": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+      "extraneous": true,
+      "dependencies": {
+        "buffer-shims": "^1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "extraneous": true,
+      "dependencies": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "extraneous": true,
+      "dependencies": {
+        "extsprintf": "1.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/wide-align": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+      "extraneous": true,
+      "dependencies": {
+        "string-width": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/fsevents/node_modules/xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "extraneous": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "extraneous": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "extraneous": true,
+      "dependencies": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "extraneous": true,
+      "dependencies": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/globals": {
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+      "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "extraneous": true,
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "extraneous": true,
+      "dependencies": {
+        "function-bind": "^1.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/hash.js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/hmac-drbg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz",
+      "integrity": "sha1-PbRx9FquSplKBogyIXH1G4uRvuU=",
+      "extraneous": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "extraneous": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/hosted-git-info": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
+      "integrity": "sha1-SwRF5BwASovRM3dzpP95DKQDGMg=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ignore": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz",
+      "integrity": "sha1-JujaBkS+C7TLOVFvbHnw4PT/5Iw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "extraneous": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/interpret": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
+      "integrity": "sha1-9PYj8LtxIvFfVxfI4lS4FhtcWy0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "extraneous": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "extraneous": true,
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "extraneous": true,
+      "dependencies": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-dotfile": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "extraneous": true,
+      "dependencies": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "extraneous": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "extraneous": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "extraneous": true,
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-my-json-valid": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "extraneous": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "extraneous": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "extraneous": true,
+      "dependencies": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "extraneous": true,
+      "dependencies": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "extraneous": true,
+      "dependencies": {
+        "has": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "extraneous": true,
+      "dependencies": {
+        "tryit": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "extraneous": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/js-tokens": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/js-yaml": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.2.tgz",
+      "integrity": "sha1-AtPiwPa+qyAkjUEsNSIDgn14ZyE=",
+      "extraneous": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^3.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/json-loader": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
+      "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "extraneous": true,
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/jsx-ast-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz",
+      "integrity": "sha1-Wv44ho9WvIzHrq7wEAuox1vRJZE=",
+      "extraneous": true,
+      "dependencies": {
+        "object-assign": "^4.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/kind-of": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+      "extraneous": true,
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "extraneous": true,
+      "dependencies": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "extraneous": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "extraneous": true,
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/loader-runner": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/loader-utils": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "extraneous": true,
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/lodash.cond": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "extraneous": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "extraneous": true,
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "extraneous": true,
+      "dependencies": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/miller-rabin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+      "extraneous": true,
+      "dependencies": {
+        "brace-expansion": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "extraneous": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/nan": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+      "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/node-libs-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "extraneous": true,
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/normalize-package-data": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
+      "integrity": "sha1-SY+kIMlkAfeHQCuiHmAN75+YH/8=",
+      "extraneous": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "extraneous": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "extraneous": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.0",
+        "object-keys": "^1.0.10"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "extraneous": true,
+      "dependencies": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "extraneous": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "extraneous": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/optionator/node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/os-browserify": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "extraneous": true,
+      "dependencies": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/parchment": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.0.8.tgz",
+      "integrity": "sha1-E+xr7M5sFnSB8Xcr1RpZBt51oDg="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "extraneous": true,
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "extraneous": true,
+      "dependencies": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "extraneous": true,
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "extraneous": true,
+      "dependencies": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pbkdf2": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+      "integrity": "sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM=",
+      "extraneous": true,
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "extraneous": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "extraneous": true,
+      "dependencies": {
+        "find-up": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pkg-up": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+      "extraneous": true,
+      "dependencies": {
+        "find-up": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/private": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/process": {
+      "version": "0.11.9",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+      "integrity": "sha1-e9WtIapiU+fahoImTx4R0RwDGME=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/prr": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "extraneous": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/quill": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.2.3.tgz",
+      "integrity": "sha1-j8Yu1m2Bc+35vB2ft3fddOsGMu4=",
+      "dependencies": {
+        "clone": "~2.1.1",
+        "deep-equal": "~1.0.1",
+        "eventemitter3": "~2.0.2",
+        "extend": "~3.0.0",
+        "parchment": "1.0.8",
+        "quill-delta": "3.5.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/quill-delta": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.5.0.tgz",
+      "integrity": "sha1-W2fmhdpgw06r7URJxBbHSquJFXs=",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.0",
+        "fast-diff": "1.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/randomatic": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+      "extraneous": true,
+      "dependencies": {
+        "is-number": "^2.0.2",
+        "kind-of": "^3.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/randombytes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+      "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "extraneous": true,
+      "dependencies": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "extraneous": true,
+      "dependencies": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/readable-stream": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+      "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
+      "extraneous": true,
+      "dependencies": {
+        "buffer-shims": "^1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "extraneous": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "extraneous": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "extraneous": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regenerate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regenerator-runtime": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
+      "integrity": "sha1-jENnqQS1HqYqkIrDEL+Z/5CoKj4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regenerator-transform": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
+      "integrity": "sha1-D4i7K8A5Mt23trcxLmgHjwECbWw=",
+      "extraneous": true,
+      "dependencies": {
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regex-cache": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "extraneous": true,
+      "dependencies": {
+        "is-equal-shallow": "^0.1.3",
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "extraneous": true,
+      "dependencies": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "extraneous": true,
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/remove-trailing-separator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+      "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "extraneous": true,
+      "dependencies": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "extraneous": true,
+      "dependencies": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/resolve": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
+      "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
+      "extraneous": true,
+      "dependencies": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "extraneous": true,
+      "dependencies": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "extraneous": true,
+      "dependencies": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "extraneous": true,
+      "dependencies": {
+        "glob": "^7.0.5"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/ripemd160": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+      "integrity": "sha1-k6S71JQrxXS2mo+lfHHeEOzKfW4=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "extraneous": true,
+      "dependencies": {
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/sha.js": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/shelljs": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "extraneous": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/source-list-map": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.1.tgz",
+      "integrity": "sha1-GjOsIQyhRNHlYfkG68yrVmn/TLQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/source-map-support": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+      "integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
+      "extraneous": true,
+      "dependencies": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "extraneous": true,
+      "dependencies": {
+        "spdx-license-ids": "^1.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/stream-http": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz",
+      "integrity": "sha1-zsH047SUvEqBtFGAiXD4sgtO1fY=",
+      "extraneous": true,
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "extraneous": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "extraneous": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "extraneous": true,
+      "dependencies": {
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
+        "slice-ansi": "0.0.4",
+        "string-width": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/table/node_modules/string-width": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+      "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+      "extraneous": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/tapable": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
+      "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/timers-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+      "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
+      "extraneous": true,
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/to-fast-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+      "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "extraneous": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/uglify-js": {
+      "version": "2.8.20",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.20.tgz",
+      "integrity": "sha1-vocQD7wY3jh27WBunSS0VoMRzs8=",
+      "extraneous": true,
+      "dependencies": {
+        "source-map": "~0.5.1",
+        "yargs": "~3.10.0"
+      },
+      "optionalDependencies": {
+        "uglify-to-browserify": "~1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "extraneous": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "extraneous": true,
+      "dependencies": {
+        "inherits": "2.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/util/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/v8flags": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
+      "integrity": "sha1-cyNdn3F2+OiDP7KGeVRF95ONhOU=",
+      "extraneous": true,
+      "dependencies": {
+        "user-home": "^1.1.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "extraneous": true,
+      "dependencies": {
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "extraneous": true,
+      "dependencies": {
+        "indexof": "0.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/watchpack": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
+      "integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
+      "extraneous": true,
+      "dependencies": {
+        "async": "^2.1.2",
+        "chokidar": "^1.4.3",
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.3.3.tgz",
+      "integrity": "sha1-7swIPBj7e/lY6k9AtXpmQMWgzHg=",
+      "extraneous": true,
+      "dependencies": {
+        "acorn": "^4.0.4",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.1.1",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.0.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^0.2.16",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.2.5",
+        "uglify-js": "^2.8.5",
+        "watchpack": "^1.3.1",
+        "webpack-sources": "^0.2.3",
+        "yargs": "^6.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack-sources": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
+      "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
+      "extraneous": true,
+      "dependencies": {
+        "source-list-map": "^1.1.1",
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack/node_modules/acorn": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+      "integrity": "sha1-7c2jvZN+dVZBDULtWGD2c5nHlMA=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack/node_modules/camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack/node_modules/cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "extraneous": true,
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack/node_modules/supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "extraneous": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/webpack/node_modules/yargs": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+      "extraneous": true,
+      "dependencies": {
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^4.2.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "extraneous": true,
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "extraneous": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "extraneous": true
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "extraneous": true,
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/yargs-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+      "extraneous": true,
+      "dependencies": {
+        "camelcase": "^3.0.0"
+      }
+    },
+    "node_modules/quill-image-resize-module--fix-imports-error/node_modules/yargs-parser/node_modules/camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "extraneous": true
     },
     "node_modules/quill/node_modules/deep-equal": {
       "version": "1.1.2",

--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -26,6 +26,7 @@
         "react-intersection-observer": "^9.13.1",
         "react-js-pagination": "^3.0.3",
         "react-quill": "^2.0.0",
+        "react-quill-new": "^3.3.3",
         "react-redux": "^9.1.2",
         "react-slick": "^0.30.2",
         "redux-persist": "^6.0.0",
@@ -21278,6 +21279,20 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-quill-new": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.3.3.tgz",
+      "integrity": "sha512-jxbm1QUJlkuGUpc9/GUgGw5USLHdp43H0M7AufqS3V+zRLng9uqLeVBGjXYqEbUKi8QVOM4SClSV3F7kVNj68w==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "quill": "~2.0.2"
+      },
+      "peerDependencies": {
+        "quill-delta": "^5.1.0",
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-quill/node_modules/deep-equal": {

--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -8,8 +8,11 @@
       "name": "dutchiepay",
       "version": "0.1.0",
       "dependencies": {
+        "@looop/quill-image-resize-module-react": "^3.1.5",
         "@portone/browser-sdk": "^0.0.10",
         "@reduxjs/toolkit": "^2.2.7",
+        "@xeger/quill-image-actions": "^0.7.2",
+        "@xeger/quill-image-formats": "^0.7.2",
         "axios": "^1.7.5",
         "crypto-js": "^4.2.0",
         "dutchiepay": "file:",
@@ -17,7 +20,9 @@
         "next": "14.2.5",
         "next-image-export-optimizer": "^1.15.1",
         "npm": "^10.9.0",
-        "quill": "^2.0.2",
+        "quill": "^1.3.6",
+        "quill-image-resize": "^3.0.9",
+        "quill-image-resize-module": "^3.0.0",
         "react": "^18",
         "react-content-loader": "^7.0.2",
         "react-daum-postcode": "^3.1.3",
@@ -3795,6 +3800,15 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
     },
+    "node_modules/@looop/quill-image-resize-module-react": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@looop/quill-image-resize-module-react/-/quill-image-resize-module-react-3.1.5.tgz",
+      "integrity": "sha512-Rr8R8ScVoKYFzSKMG92sWv91AFggOq0qovrToRoVJFMVxHavltLdrpUIzsEXxsRkECI7EY+SSyiXFIu2Cj5W1Q==",
+      "peerDependencies": {
+        "lodash": "^4.17.20",
+        "quill": "^1.3.7"
+      }
+    },
     "node_modules/@mdx-js/react": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.0.1.tgz",
@@ -7507,11 +7521,6 @@
         "parchment": "^1.1.2"
       }
     },
-    "node_modules/@types/quill/node_modules/parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
-    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -8084,6 +8093,29 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xeger/quill-image-actions": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@xeger/quill-image-actions/-/quill-image-actions-0.7.2.tgz",
+      "integrity": "sha512-OhaZnYCie9J1ZLx2+Nsznj+qkdHn9Yx7q3iOCCKFs6kAzcZUVBPv2fMjK+nzURySLyCVQOP3Ur2mZx1yYqgppw==",
+      "dependencies": {
+        "core-js": "^3.0",
+        "deepmerge": "^4.2"
+      },
+      "peerDependencies": {
+        "quill": "^1.3.6"
+      }
+    },
+    "node_modules/@xeger/quill-image-formats": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@xeger/quill-image-formats/-/quill-image-formats-0.7.2.tgz",
+      "integrity": "sha512-L9beiJKWzjHxBJEZB21I8YjFgOHYROsrfFMvIqP+kjc/u/MecHY1mXzR9VySLr+Qvj55t+vkKKuJ0ZPKvQSaPA==",
+      "dependencies": {
+        "core-js": "^3.0"
+      },
+      "peerDependencies": {
+        "quill": "^1.3.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -9953,6 +9985,16 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
+      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.38.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
@@ -10451,7 +10493,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11861,9 +11902,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -20171,9 +20212,9 @@
       }
     },
     "node_modules/parchment": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
-      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -21009,17 +21050,16 @@
       ]
     },
     "node_modules/quill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.2.tgz",
-      "integrity": "sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "lodash-es": "^4.17.21",
-        "parchment": "^3.0.0",
-        "quill-delta": "^5.1.0"
-      },
-      "engines": {
-        "npm": ">=8.2.3"
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
       }
     },
     "node_modules/quill-delta": {
@@ -21033,6 +21073,63 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/quill-image-resize": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/quill-image-resize/-/quill-image-resize-3.0.9.tgz",
+      "integrity": "sha512-5Dk0nixhbFsCwSWtPU9qqqtfM2gURfaP+pbBhQvAoMJoF4p99xbAibfAI3gsZJkbWUodoK2iAPf1V5oTSpv9ww==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "quill": "^1.2.2",
+        "raw-loader": "^0.5.1"
+      }
+    },
+    "node_modules/quill-image-resize-module": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quill-image-resize-module/-/quill-image-resize-module-3.0.0.tgz",
+      "integrity": "sha512-1TZBnUxU/WIx5dPyVjQ9yN7C6mLZSp04HyWBEMqT320DIq4MW4JgzlOPDZX5ZpBM3bU6sacU4kTLUc8VgYQZYw==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "quill": "^1.2.2",
+        "raw-loader": "^0.5.1"
+      }
+    },
+    "node_modules/quill/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+    },
+    "node_modules/quill/node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/ramda": {
@@ -21087,6 +21184,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q=="
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -21295,64 +21397,28 @@
         "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/react-quill/node_modules/deep-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-      "dependencies": {
-        "is-arguments": "^1.1.1",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+    "node_modules/react-quill-new/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
-    "node_modules/react-quill/node_modules/eventemitter3": {
+    "node_modules/react-quill-new/node_modules/parchment": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="
+    },
+    "node_modules/react-quill-new/node_modules/quill": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
-    },
-    "node_modules/react-quill/node_modules/fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
-    },
-    "node_modules/react-quill/node_modules/parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
-    },
-    "node_modules/react-quill/node_modules/quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "dependencies": {
-        "clone": "^2.1.1",
-        "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
-        "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
-      }
-    },
-    "node_modules/react-quill/node_modules/quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
       },
       "engines": {
-        "node": ">=0.10"
+        "npm": ">=8.2.3"
       }
     },
     "node_modules/react-redux": {

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -29,6 +29,7 @@
     "quill": "^1.3.6",
     "quill-image-resize": "^3.0.9",
     "quill-image-resize-module": "^3.0.0",
+    "quill-image-resize-module--fix-imports-error": "^3.0.0",
     "react": "^18",
     "react-content-loader": "^7.0.2",
     "react-daum-postcode": "^3.1.3",

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -32,6 +32,7 @@
     "react-intersection-observer": "^9.13.1",
     "react-js-pagination": "^3.0.3",
     "react-quill": "^2.0.0",
+    "react-quill-new": "^3.3.3",
     "react-redux": "^9.1.2",
     "react-slick": "^0.30.2",
     "redux-persist": "^6.0.0",

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -14,8 +14,11 @@
     "test": "jest"
   },
   "dependencies": {
+    "@looop/quill-image-resize-module-react": "^3.1.5",
     "@portone/browser-sdk": "^0.0.10",
     "@reduxjs/toolkit": "^2.2.7",
+    "@xeger/quill-image-actions": "^0.7.2",
+    "@xeger/quill-image-formats": "^0.7.2",
     "axios": "^1.7.5",
     "crypto-js": "^4.2.0",
     "dutchiepay": "file:",
@@ -23,7 +26,9 @@
     "next": "14.2.5",
     "next-image-export-optimizer": "^1.15.1",
     "npm": "^10.9.0",
-    "quill": "^2.0.2",
+    "quill": "^1.3.6",
+    "quill-image-resize": "^3.0.9",
+    "quill-image-resize-module": "^3.0.0",
     "react": "^18",
     "react-content-loader": "^7.0.2",
     "react-daum-postcode": "^3.1.3",

--- a/dutchiepay/src/app/(routes)/community/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/write/page.jsx
@@ -4,7 +4,7 @@ import '@/styles/community.css';
 
 import Image from 'next/image';
 import Link from 'next/link';
-import TextEditor from '@/app/_components/_community/TextEditor';
+import TextEditor from '@/app/_components/_community/_post/TextEditor';
 import { useState } from 'react';
 
 export default function CommunityWrite() {

--- a/dutchiepay/src/app/(routes)/mart/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/write/page.jsx
@@ -8,15 +8,16 @@ import HeadCount from '@/app/_components/_community/_post/HeadCount';
 import Location_Modal from '@/app/(routes)/location/page';
 import MettingPlaceInput from '@/app/_components/_community/_post/MeetingPlaceInput';
 import PostWritingAction from '@/app/_components/_community/_post/PostWritingAction';
-import TextEditor from '@/app/_components/_community/TextEditor';
+import TextEditor from '@/app/_components/_community/_post/TextEditor';
 import TitleInput from '@/app/_components/_community/_post/TitleInput';
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 
 export default function MartWrite() {
   const [filter, setFilter] = useState('마트');
-  const [isModalOpen, setIsModalOpen] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [locationDescription, setLocationDescription] = useState('');
+  const [editorContent, setEditorContent] = useState('');
   const {
     register,
     watch,
@@ -38,6 +39,7 @@ export default function MartWrite() {
 
   const onSubmit = async (formData) => {
     console.log(formData);
+    console.log(editorContent);
   };
 
   return (
@@ -64,7 +66,7 @@ export default function MartWrite() {
               입력 가능합니다.
             </small>
           </div>
-          <TextEditor />
+          <TextEditor setEditorContent={setEditorContent} />
           <PostWritingAction />
         </form>
       )}

--- a/dutchiepay/src/app/(routes)/mart/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/write/page.jsx
@@ -2,27 +2,32 @@
 
 import '@/styles/community.css';
 
-import Image from 'next/image';
-import Link from 'next/link';
+import CommunityFilter from '@/app/_components/_community/_post/CommunityFilter';
+import DateInput from '@/app/_components/_community/_post/DateInput';
+import HeadCount from '@/app/_components/_community/_post/HeadCount';
 import Location_Modal from '@/app/(routes)/location/page';
+import MettingPlaceInput from '@/app/_components/_community/_post/MeetingPlaceInput';
+import PostWritingAction from '@/app/_components/_community/_post/PostWritingAction';
 import TextEditor from '@/app/_components/_community/TextEditor';
+import TitleInput from '@/app/_components/_community/_post/TitleInput';
+import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 
 export default function MartWrite() {
   const [filter, setFilter] = useState('마트');
-  const [headcount, setHeadcount] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(true);
   const [locationDescription, setLocationDescription] = useState('');
-
-  const handleHeadcount = (e) => {
-    if (e.target.value === '-') {
-      if (headcount === 1) return;
-      setHeadcount(headcount - 1);
-    } else {
-      if (headcount === 10) return;
-      setHeadcount(headcount + 1);
-    }
-  };
+  const {
+    register,
+    watch,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    defaultValues: {
+      headCount: 2,
+    },
+  });
 
   const handleLocationUpdate = (description) => {
     console.log(locationDescription);
@@ -31,149 +36,36 @@ export default function MartWrite() {
     setIsModalOpen(false);
   };
 
+  const onSubmit = async (formData) => {
+    console.log(formData);
+  };
+
   return (
-    <section className="min-h-[750px] w-[1020px] mb-[100px] mt-[60px] mx-[60px]">
+    <section className="min-h-[750px] w-[1020px] mb-[100px] mt-[40px] mx-[60px]">
       {isModalOpen ? (
         <Location_Modal onLocationUpdate={handleLocationUpdate} />
       ) : (
-        <form>
-          <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
-            <label className="community__label" htmlFor="category">
-              카테고리
-            </label>
-            <small className="community__label-description">
-              작성하실 게시글의 카테고리를 선택해주세요.
-            </small>
-          </div>
-          <ul className="flex gap-[16px]">
-            <li>
-              <button
-                className={`community__filter ${filter === '마트' ? `community__filter--selected` : ''}`}
-                onClick={() => setFilter('마트')}
-                type="button"
-              >
-                마트
-              </button>
-            </li>
-            <li>
-              <button
-                className={`community__filter ${filter === '배달' ? `community__filter--selected` : ''}`}
-                onClick={() => setFilter('배달')}
-                type="button"
-              >
-                배달
-              </button>
-            </li>
-          </ul>
-
-          <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
-            <label className="community__label" htmlFor="title">
-              제목
-            </label>
-            <small className="community__label-description">
-              게시글 제목을 입력해주세요. 최대 60글자까지 입력 가능합니다.
-            </small>
-          </div>
-          <input
-            id="title"
-            className="community__input-text"
-            type="text"
-            placeholder="게시글 제목"
-            aria-required="true"
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <CommunityFilter
+            categories={['마트', '배달']}
+            filter={filter}
+            setFilter={setFilter}
           />
+          <TitleInput register={register} />
+          <DateInput register={register} setValue={setValue} />
+          <MettingPlaceInput />
+          <HeadCount register={register} setValue={setValue} watch={watch} />
           <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
-            <label className="community__label" htmlFor="date">
-              일시
-            </label>
-            <small className="community__label-description">
-              마트/배달을 희망하는 날짜와 시간을 입력해주세요.
-            </small>
-          </div>
-          <div className="flex gap-[8px]">
-            <input id="date" className="community__input-date" type="date" />
-            <input className="community__input-date" type="time" />
-          </div>
-          <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
-            <label className="community__label" htmlFor="trading-place">
-              거래 장소
-            </label>
-            <small className="community__label-description">
-              거래를 진행할 장소입니다. 수정이 불가능합니다.
-            </small>
-          </div>
-          <input
-            className="community__input-text"
-            type="text"
-            value={`${locationDescription}`}
-            disabled={true}
-          />
-          <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
-            <label className="community__label" htmlFor="max-number">
-              최대 인원 수
-            </label>
-            <small className="community__label-description">
-              마트/배달을 함께 할 최대 인원 수를 입력해주세요.
-            </small>
-          </div>
-          <div className="w-full flex items-center gap-[4px] mb-[12px]">
-            <button
-              className="community__button-number"
-              value="-"
-              onClick={(e) => handleHeadcount(e)}
-              type="button"
-            >
-              -
-            </button>
-            <input
-              id="max-number"
-              className="border w-[32px] h-[32px] font-bold text-center community__input-number"
-              type="number"
-              value={headcount}
-              defaultValue={headcount}
-              onChange={(e) => {
-                const newValue = parseInt(e.target.value, 10);
-                if (newValue >= 1) {
-                  setHeadcount(newValue);
-                }
-              }}
-              min={1}
-              max={10}
-              aria-required="true"
-            />
-            <button
-              className="community__button-number"
-              value="+"
-              onClick={(e) => handleHeadcount(e)}
-              type="button"
-            >
-              +
-            </button>
-          </div>
-          <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
-            <label className="community__label" htmlFor="content">
+            <label className="font-bold text-lg" htmlFor="content">
               내용
             </label>
-            <small className="community__label-description">
-              나눔/거래에 대해 추가적인 설명이 필요하신 경우 작성해주세요. 최대
-              3,000글자까지 입력 가능합니다.
+            <small className="text-sm text-gray--500">
+              추가적인 설명이 필요하신 경우 작성해주세요. 최대 3,000글자까지
+              입력 가능합니다.
             </small>
           </div>
           <TextEditor />
-          <div className="flex justify-center gap-[16px] mt-[48px]">
-            <button
-              className="bg-blue--500 text-white text-lg font-semibold rounded-lg px-[60px] py-[8px]"
-              type="submit"
-            >
-              등록
-            </button>
-            <Link
-              href="/mart"
-              className="border border-blue--500 text-blue--500 text-lg font-semibold rounded-lg px-[60px] py-[6px]"
-              role="button"
-            >
-              취소
-            </Link>
-          </div>
+          <PostWritingAction />
         </form>
       )}
     </section>

--- a/dutchiepay/src/app/(routes)/used/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/used/write/page.jsx
@@ -5,7 +5,7 @@ import '@/styles/community.css';
 import Image from 'next/image';
 import Link from 'next/link';
 import Location_Modal from '@/app/(routes)/location/page';
-import TextEditor from '@/app/_components/_community/TextEditor';
+import TextEditor from '@/app/_components/_community/_post/TextEditor';
 import { useState } from 'react';
 
 export default function UsedWrite() {

--- a/dutchiepay/src/app/_components/_community/TextEditor.jsx
+++ b/dutchiepay/src/app/_components/_community/TextEditor.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import '@/styles/globals.css';
-import 'react-quill/dist/quill.snow.css';
+import 'react-quill-new/dist/quill.snow.css';
 
 import { useMemo, useState } from 'react';
 
@@ -9,7 +9,7 @@ import Image from 'next/image';
 import dynamic from 'next/dynamic';
 import image from '../../../../public/image/reviewImg/reviewImg1.jpg';
 
-const ReactQuill = dynamic(() => import('react-quill'), {
+const ReactQuill = dynamic(() => import('react-quill-new'), {
   ssr: false,
 });
 
@@ -24,11 +24,10 @@ export default function TextEditor() {
           [{ header: [1, 2, 3, 4, 5, false] }],
           ['bold', 'italic', 'underline', 'strike'],
           ['blockquote', 'code-block'],
-          [{ list: 'ordered' }, { list: 'bullet' }],
           [{ color: [] }, { background: [] }],
           [{ align: [] }],
-          ['clean'],
           ['image'],
+          ['link'],
         ],
       },
     }),
@@ -40,12 +39,14 @@ export default function TextEditor() {
     'bold',
     'italic',
     'underline',
-    'list',
-    'bullet',
+    'strike',
+    'blockquote',
+    'code-block',
     'link',
     'image',
     'color',
     'background',
+    'align',
   ];
 
   return (
@@ -65,13 +66,8 @@ export default function TextEditor() {
           </small>
         </div>
         <div className="flex gap-[4px] mt-[4px]">
-          <div className="w-[60px] h-[60px] border relative">
-            <Image
-              src={image}
-              alt="첨부이미지"
-              fill
-              style={{ objectFit: 'cover' }}
-            />
+          <div className="w-[60px] h-[60px] border relative object-cover">
+            <Image src={image} alt="첨부이미지" fill />
             {isThumbnail && (
               <div className="text-[10px] text-white bg-blue--500 py-[2px] px-[4px] absolute top-0 left-0">
                 대표

--- a/dutchiepay/src/app/_components/_community/_post/CommunityFilter.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/CommunityFilter.jsx
@@ -1,0 +1,29 @@
+export default function CommunityFilter({ categories, filter, setFilter }) {
+  return (
+    <>
+      <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
+        <label className="font-bold text-lg" htmlFor="category">
+          카테고리
+        </label>
+        <small className="text-sm text-gray--500">
+          작성하실 게시글의 카테고리를 선택해주세요.
+        </small>
+      </div>
+      <ul className="flex gap-[16px]">
+        {categories.map((value, key) => {
+          return (
+            <li key={key}>
+              <button
+                className={`py-[6px] px-[16px] text-blue--500 text-sm border border-blue--500 rounded-2xl transition-all duration-300 ease-in-out ${filter === value ? 'bg-blue--500 text-white' : ''}`}
+                onClick={() => setFilter(value)}
+                type="button"
+              >
+                {value}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/DateInput.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/DateInput.jsx
@@ -1,0 +1,49 @@
+export default function DateInput({ register, setValue }) {
+  const handleDateTimeChange = () => {
+    const dateInput = document.getElementById('date').value;
+    const timeInput = document.getElementById('time').value;
+
+    if (dateInput && timeInput) {
+      const date = new Date(`${dateInput}T${timeInput}`);
+      const options = {
+        year: undefined,
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+      };
+      const formatted = date.toLocaleString('ko-KR', options);
+
+      setValue('formattedDateTime', formatted);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
+        <label className="font-bold text-lg" htmlFor="date">
+          일시
+        </label>
+        <small className="text-sm text-gray--500">
+          희망하는 날짜와 시간을 입력해주세요.
+        </small>
+      </div>
+      <div className="flex gap-[8px]">
+        <input
+          id="date"
+          className="w-[150px] border rounded-lg outline-none px-[12px] py-[8px] text-sm"
+          type="date"
+          {...register('date', { onChange: handleDateTimeChange })}
+        />
+        <input
+          id="time"
+          className="w-[150px] border rounded-lg outline-none px-[12px] py-[8px] text-sm"
+          type="time"
+          {...register('time', { onChange: handleDateTimeChange })}
+        />
+      </div>
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/HeadCount.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/HeadCount.jsx
@@ -1,0 +1,71 @@
+export default function HeadCount({ register, setValue, watch }) {
+  const headCount = watch('headCount', 2);
+
+  const handleHeadCount = (operation) => {
+    if (operation === '-') {
+      if (headCount <= 2) {
+        alert('본인을 포함 최소 2명이 필요합니다.');
+        return;
+      }
+      setValue('headCount', headCount - 1);
+    } else if (operation === '+') {
+      if (headCount >= 10) {
+        alert('최대 10명까지만 마트/배달에 참여할 수 있습니다.');
+        return;
+      }
+      setValue('headCount', headCount + 1);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
+        <label className="font-bold text-lg" htmlFor="max-number">
+          최대 인원 수
+        </label>
+        <small className="text-sm text-gray--500">
+          본인을 포함하여 마트/배달을 함께 할 최대 인원 수를 입력해주세요. 최대
+          10명까지만 선택 가능합니다.
+        </small>
+      </div>
+      <div className="w-full flex items-center gap-[4px] mb-[12px]">
+        <button
+          className="w-[25px] h-[25px] bg-blue--500 text-white font-bold rounded"
+          value="-"
+          onClick={() => handleHeadCount('-')}
+          type="button"
+        >
+          -
+        </button>
+        <input
+          id="max-number"
+          className="border w-[32px] h-[32px] font-bold text-center"
+          type="number"
+          {...register('headCount', {
+            value: 2,
+            min: 2,
+            max: 10,
+            onChange: (e) => {
+              const newValue = parseInt(e.target.value, 10);
+              if (newValue >= 2 && newValue <= 10) {
+                setValue('headCount', newValue);
+              } else {
+                alert('최소 2명, 최대 10명까지만 가능합니다.');
+                setValue('headCount', headCount);
+              }
+            },
+          })}
+          aria-required="true"
+        />
+        <button
+          className="w-[25px] h-[25px] bg-blue--500 text-white font-bold rounded"
+          value="+"
+          onClick={() => handleHeadCount('+')}
+          type="button"
+        >
+          +
+        </button>
+      </div>
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/MeetingPlaceInput.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/MeetingPlaceInput.jsx
@@ -1,0 +1,21 @@
+export default function MettingPlaceInput({ locationDescription }) {
+  return (
+    <>
+      <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
+        <label className="font-bold text-lg" htmlFor="trading-place">
+          거래 장소
+        </label>
+        <small className="text-sm text-gray--500">
+          거래를 진행할 장소입니다.
+        </small>
+      </div>
+      <input
+        className="w-[600px] border rounded-lg outline-none py-[8px] px-[12px] placeholder:text-sm"
+        type="text"
+        value={`${locationDescription}`}
+        placeholder="거래 장소"
+        disabled={true}
+      />
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/PostWritingAction.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/PostWritingAction.jsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function PostWritingAction() {
+  return (
+    <div className="flex justify-center gap-[16px] mt-[48px]">
+      <button
+        className="bg-blue--500 text-white text-lg font-semibold rounded-lg px-[60px] py-[8px]"
+        type="submit"
+      >
+        등록
+      </button>
+      <Link
+        href="/mart"
+        className="border border-blue--500 text-blue--500 text-lg font-semibold rounded-lg px-[60px] py-[6px]"
+        role="button"
+      >
+        취소
+      </Link>
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/TextEditor.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/TextEditor.jsx
@@ -2,12 +2,12 @@
 
 import 'react-quill-new/dist/quill.snow.css';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Image from 'next/image';
+import UploadedImages from './UploadedImages';
 import dynamic from 'next/dynamic';
 import getImage from '@/app/_util/getImage';
-import image from '/public/image/reviewImg/reviewImg1.jpg';
 import { useRef } from 'react';
 
 const ReactQuill = dynamic(
@@ -28,8 +28,8 @@ const ReactQuill = dynamic(
 
 ReactQuill.displayName = 'ReactQuillComponent';
 
-export default function TextEditor() {
-  const [editorContent, setEditorContent] = useState('');
+export default function TextEditor({ setEditorContent }) {
+  const [images, setImages] = useState([]);
   const [isThumbnail, setIsThumbnail] = useState(false);
   const quillRef = useRef(null);
 
@@ -47,6 +47,7 @@ export default function TextEditor() {
           const quill = quillRef.current.getEditor();
           const range = quill.getSelection();
           quill.insertEmbed(range.index, 'image', imageUrl);
+          setImages((prevImages) => [...prevImages, imageUrl]);
         }
       }
     };
@@ -94,27 +95,7 @@ export default function TextEditor() {
         modules={modules}
         formats={formats}
       />
-      <div className="w-full h-[100px] border border-[#ccc] py-[8px] px-[12px]">
-        <div className="flex gap-[4px] items-end">
-          <p className="text-sm font-bold">이미지 (3/10)</p>
-          <small className="text-xs text-gray--500">
-            게시글의 메인 이미지로 사용할 대표 이미지를 선택해주세요.{' '}
-          </small>
-        </div>
-        <div className="flex gap-[4px] mt-[4px]">
-          <div className="w-[60px] h-[60px] border relative object-cover">
-            <Image src={image} alt="첨부이미지" fill />
-            {isThumbnail && (
-              <div className="text-[10px] text-white bg-blue--500 py-[2px] px-[4px] absolute top-0 left-0">
-                대표
-              </div>
-            )}
-            <button className="w-[15px] h-[15px] text-[10px] text-white font-medium bg-red--500 absolute top-0 right-0">
-              X
-            </button>
-          </div>
-        </div>
-      </div>
+      <UploadedImages isThumbnail={isThumbnail} images={images} />
     </>
   );
 }

--- a/dutchiepay/src/app/_components/_community/_post/TitleInput.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/TitleInput.jsx
@@ -1,0 +1,28 @@
+export default function TitleInput({ register }) {
+  return (
+    <>
+      <div className="flex items-center gap-[12px] mt-[24px] mb-[8px]">
+        <label className="font-bold text-lg" htmlFor="title">
+          제목
+        </label>
+        <small className="text-sm text-gray--500">
+          게시글 제목을 입력해주세요. 최대 60글자까지 입력 가능합니다.
+        </small>
+      </div>
+      <input
+        id="title"
+        className="w-[600px] border rounded-lg outline-none py-[8px] px-[12px] placeholder:text-sm"
+        type="text"
+        placeholder="게시글 제목"
+        aria-required="true"
+        {...register('title', {
+          required: '제목을 입력해주세요',
+          maxLength: {
+            value: 60,
+            message: '게시글 제목은 60자까지 입력 가능합니다.',
+          },
+        })}
+      />
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/UploadedImages.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/UploadedImages.jsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+
+export default function UploadedImages({ isThumbnail, images }) {
+  return (
+    <div className="w-full h-[100px] border-x border-b border-[#ccc] py-[8px] px-[12px]">
+      <div className="flex gap-[4px] items-end">
+        <p className="text-sm font-bold">이미지 ({images.length}/10)</p>
+        <small className="text-xs text-gray--500">
+          게시글의 메인 이미지로 사용할 대표 이미지를 선택해주세요.
+        </small>
+      </div>
+      <div className="flex gap-[4px] mt-[4px]">
+        {images.map((img, key) => {
+          return (
+            <div
+              className="w-[60px] h-[60px] border relative object-cover"
+              key={key}
+            >
+              <Image src={img} alt="첨부이미지" fill />
+              {isThumbnail && (
+                <div className="text-[10px] text-white bg-blue-500 py-[2px] px-[4px] absolute top-0 left-0">
+                  대표
+                </div>
+              )}
+              <button
+                className="w-[15px] h-[15px] text-[10px] text-white font-medium bg-red-500 absolute top-0 right-0"
+                type="button"
+              >
+                X
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_post/UploadedImages.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/UploadedImages.jsx
@@ -1,12 +1,46 @@
 import Image from 'next/image';
 
-export default function UploadedImages({ isThumbnail, images }) {
+export default function UploadedImages({
+  quillRef,
+  thumbnail,
+  setThumbnail,
+  images,
+  setImages,
+}) {
+  const handleThumbnail = (img) => {
+    if (thumbnail === img) return;
+    setThumbnail(img);
+  };
+
+  const handleImageDelete = (img) => {
+    if (img === thumbnail) {
+      alert(
+        '대표 이미지로 설정된 사진은 제거할 수 없습니다.\n삭제를 원할 경우 대표 이미지를 다른 이미지로 변경해주세요.'
+      );
+      return;
+    }
+    setImages((prevImages) => prevImages.filter((image) => image !== img));
+
+    const quill = quillRef.current.getEditor();
+    const delta = quill.getContents();
+
+    const updatedDelta = delta.filter((op) => {
+      if (op.insert && op.insert.image === img) {
+        return false;
+      }
+      return true;
+    });
+
+    quill.setContents(updatedDelta);
+  };
+
   return (
     <div className="w-full h-[100px] border-x border-b border-[#ccc] py-[8px] px-[12px]">
       <div className="flex gap-[4px] items-end">
         <p className="text-sm font-bold">이미지 ({images.length}/10)</p>
         <small className="text-xs text-gray--500">
-          게시글의 메인 이미지로 사용할 대표 이미지를 선택해주세요.
+          원하는 이미지를 클릭 시 대표이미지로 설정됩니다. X 버튼을 누를 경우,
+          게시글에서 이미지가 제거됩니다.
         </small>
       </div>
       <div className="flex gap-[4px] mt-[4px]">
@@ -16,8 +50,13 @@ export default function UploadedImages({ isThumbnail, images }) {
               className="w-[60px] h-[60px] border relative object-cover"
               key={key}
             >
-              <Image src={img} alt="첨부이미지" fill />
-              {isThumbnail && (
+              <Image
+                src={img}
+                alt="첨부이미지"
+                fill
+                onClick={() => handleThumbnail(img)}
+              />
+              {thumbnail === img && (
                 <div className="text-[10px] text-white bg-blue-500 py-[2px] px-[4px] absolute top-0 left-0">
                   대표
                 </div>
@@ -25,6 +64,7 @@ export default function UploadedImages({ isThumbnail, images }) {
               <button
                 className="w-[15px] h-[15px] text-[10px] text-white font-medium bg-red-500 absolute top-0 right-0"
                 type="button"
+                onClick={() => handleImageDelete(img)}
               >
                 X
               </button>

--- a/dutchiepay/src/app/_components/_community/_post/UploadedImages.jsx
+++ b/dutchiepay/src/app/_components/_community/_post/UploadedImages.jsx
@@ -13,13 +13,14 @@ export default function UploadedImages({
   };
 
   const handleImageDelete = (img) => {
-    if (img === thumbnail) {
-      alert(
-        '대표 이미지로 설정된 사진은 제거할 수 없습니다.\n삭제를 원할 경우 대표 이미지를 다른 이미지로 변경해주세요.'
-      );
-      return;
-    }
-    setImages((prevImages) => prevImages.filter((image) => image !== img));
+    setImages((prevImages) => {
+      const updatedImages = prevImages.filter((image) => image !== img);
+      // 썸네일이 삭제된 경우
+      if (img === thumbnail) {
+        setThumbnail(updatedImages[0] || '');
+      }
+      return updatedImages;
+    });
 
     const quill = quillRef.current.getEditor();
     const delta = quill.getContents();

--- a/dutchiepay/src/styles/community.css
+++ b/dutchiepay/src/styles/community.css
@@ -61,11 +61,6 @@
   font-size: 14px;
 }
 
-.quill-container {
-  height: 450px;
-  overflow: hidden;
-}
-
 .community__button-number {
   width: 25px;
   height: 25px;

--- a/dutchiepay/src/styles/community.css
+++ b/dutchiepay/src/styles/community.css
@@ -88,3 +88,15 @@
 .community__comment__textarea::placeholder {
   font-size: 14px;
 }
+
+.ql-toolbar.ql-snow {
+  position: sticky !important;
+  top: 0 !important;
+  background: white !important;
+  z-index: 10 !important;
+}
+
+.ql-editor {
+  padding-top: 50px;
+  height: 450px !important;
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/post-write -> main

## 변경 사항
1. 게시글 form을 react hook form으로 연결
2. 날짜와 시간 모두 입력될 경우, formattedDateTime을 formData에 추가하여 API 전달 형식 구현 -> 해당 형식 반환 함수는 마트/배달에서만 사용해 재사용 가능성이 없다고 판단되어 util로 구분해두지는 않았으나 추후 코드가 길어질 때에는 분류할 예정입니다.
3. 게시글 관련 컴포넌트 분리
4. react quill에서 게시글 내용이 container 영역 이상으로 커질 경우, toolbar가 사라지는 오류 해결
5. content 내용이 editor보다 길어질 경우, toolbar와 겹쳐보이는 오류 해결
6. 업로드 이미지 컴포넌트를 별도로 분리하여 관리하도록 설정
7. 이미지 업로드 핸들러를 사용하여 이미지를 서버에 업로드 한 뒤 업로드하도록 설정 -> 이미지 업로드 함수를 getImage 함수를 사용해 gif 파일 업로드가 불가능합니다. 추후 getImage 함수를 수정해 gif 파일 업로드가 가능하도록 변경할 예정입니다.
8. 이미지 업로드 시 images 배열에 추가하고, 게시글에서 제거 시 images 배열에서도 삭제되도록 구현
9. 최초 이미지 업로드 시 대표 이미지 설정
10. 이미지 목록에서 이미지를 클릭할 경우, 대표 이미지로 설정
11. 이미지 목록 내에서 이미지 X 버튼을 클릭 할 시 게시글 내에서도 이미지가 제거되도록 구현, 대표 사진일 경우 이미지가 삭제되지 않도록 설정 -> 이 경우, 게시글 내에서 이미지를 삭제할 경우 문제가 되어 게시글 내에서 대표이미지가 삭제 될 경우 대표 이미지를 ""로 변경하거나 다른 이미지로 대표이미지를 설정하는 코드로 수정할 계획입니다.
12. react-quill-new 라이브러리로 변경 -> ETC 참고
13. react quill을 dynamic import를 할 경우 ref 전달을 할 수 없는 오류 해결 -> ETC 참고

## 테스트 결과
게시글 등록 시 form 데이터 -> 카테고리 등 일부 데이터는 state로 관리됩니다. 실제 API 호출 시에 필요한 데이터들을만 모아 별도로 생성해주는 코드를 구현해야 합니다.
![image](https://github.com/user-attachments/assets/dc305029-931a-4931-9a8a-bf26274a70e6)
![image](https://github.com/user-attachments/assets/bae3e7ac-196f-4c3b-b2bb-f78d474240cb)
대표 사진 제거 시 alert
![image](https://github.com/user-attachments/assets/2d36658d-950d-4bc8-a224-4be5b85dec98)
이미지 삭제 시 목록에서도 제거
![image](https://github.com/user-attachments/assets/42806b58-3097-49ad-9d1c-d8567216ba22)

## ETC
react-quill-new 라이브러리로 변경했습니다. 같은 기능으로 동작하지만, react quill에서는 크롬에서 사용이 중지된 코드가 포함되어 있어 warning을 발생시켜 해당 문제를 해결하고자 다른 라이브러리로 변경했습니다. 자세한 내용은 아래 게시글을 참고했습니다. 
[Listener added for a synchronous 'DOMNodeInserted' DOM Mutation Event. This event type is deprecated](https://velog.io/@pds0309/Listener-added-for-a-synchronous-DOMNodeInserted-DOM-Mutation-Event.-This-event-type-is-deprecated)
quill을 dynamic import를 하면 ref를 전달할 때 forwardRef을 사용하지 않았다는 오류가 발생하여 아래와 같이 수정해두었습니다. Slider도 같은 방식으로 해결될 수 있을 듯 하지만, 다른쪽으로 우회하여 해결해두었으니 필요성이 생기지 않는다면 별도로 수정하지는 않을 계획입니다. 
[[How to access ReactQuill Ref when using dynamic import in NextJS?](https://stackoverflow.com/questions/60458247/how-to-access-reactquill-ref-when-using-dynamic-import-in-nextjs)](https://stackoverflow.com/questions/60458247/how-to-access-reactquill-ref-when-using-dynamic-import-in-nextjs)