### PR TITLE
[Feat] 자유게시판 게시글 작성, 수정, 삭제 구현

### DIFF
--- a/dutchiepay/package-lock.json
+++ b/dutchiepay/package-lock.json
@@ -15,6 +15,7 @@
         "@xeger/quill-image-formats": "^0.7.2",
         "axios": "^1.7.5",
         "crypto-js": "^4.2.0",
+        "dompurify": "^3.2.3",
         "dutchiepay": "file:",
         "install": "^0.13.0",
         "next": "14.2.5",
@@ -7583,6 +7584,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -10758,6 +10765,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/dutchiepay/package.json
+++ b/dutchiepay/package.json
@@ -21,6 +21,7 @@
     "@xeger/quill-image-formats": "^0.7.2",
     "axios": "^1.7.5",
     "crypto-js": "^4.2.0",
+    "dompurify": "^3.2.3",
     "dutchiepay": "file:",
     "install": "^0.13.0",
     "next": "14.2.5",

--- a/dutchiepay/src/app/(routes)/community/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/[id]/page.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 
-import PostContent from '@/app/_components/_community/PostContent';
+import PostContent from '@/app/_components/_community/_common/PostContent';
 import Post_Hot from '@/app/_components/_community/_free/Post_Hot';
 import Post_Similar from '@/app/_components/_community/_free/Post_Similar';
 import axios from 'axios';

--- a/dutchiepay/src/app/(routes)/community/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/[id]/page.jsx
@@ -1,23 +1,53 @@
 'use client';
 
-import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+
 import PostContent from '@/app/_components/_community/PostContent';
 import Post_Hot from '@/app/_components/_community/_free/Post_Hot';
 import Post_Similar from '@/app/_components/_community/_free/Post_Similar';
-import { useSearchParams } from 'next/navigation';
+import axios from 'axios';
+import { useSelector } from 'react-redux';
 
 export default function CommunityDetail() {
-  const searchParams = useSearchParams();
-  const postId = searchParams.get('postId');
+  const { id } = useParams();
+  const access = useSelector((state) => state.login.access);
+  const [post, setPost] = useState(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchCommunityDetail = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/free?freeId=${id}`,
+          {
+            headers: {
+              Authorization: `Bearer ${access}`,
+            },
+          }
+        );
+        setPost(response.data);
+      } catch (error) {
+        if (error.response.data.message === '액세스 토큰이 만료되었습니다.') {
+          //
+        } else if (
+          error.response.data.message === '자유 게시글을 찾을 수 없습니다.'
+        ) {
+          alert('존재하지 않는 게시글 입니다.');
+          router.push('/community');
+        } else {
+          alert('오류가 발생했습니다. 다시 시도해주세요.');
+        }
+      }
+    };
+
+    fetchCommunityDetail();
+  }, [id, access, router]);
 
   return (
     <section className="min-h-[750px] w-[1020px]">
       <div className="flex justify-between">
-        <PostContent
-          category={'정보'}
-          menu={'커뮤니티'}
-          isMyPostWritten={true}
-        />
+        {post && <PostContent menu={'community'} post={post} postId={id} />}
 
         <section className="w-[290px] h-[750px] sticky top-[150px] pl-[24px] py-[40px] flex flex-col gap-[40px]">
           <article>

--- a/dutchiepay/src/app/(routes)/community/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/page.jsx
@@ -5,9 +5,11 @@ import '@/styles/globals.css';
 
 import Link from 'next/link';
 import Post_Community from '@/app/_components/_community/Post_Community';
+import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
 export default function Community() {
+  const access = useSelector((state) => state.login.access);
   const [filter, setFilter] = useState('최신순');
 
   return (
@@ -35,7 +37,7 @@ export default function Community() {
             </li>
           </ul>
           <Link
-            href="/community/write"
+            href={`${access ? '/mart/write' : '/login'}`}
             className="text-white rounded bg-blue--500 px-[16px] py-[8px] text-sm"
             role="button"
           >

--- a/dutchiepay/src/app/(routes)/community/write/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/write/[id]/page.jsx
@@ -53,7 +53,7 @@ export default function MartModify() {
         }
       );
 
-      router.push(`/mart/${id}`);
+      router.push(`/community/${id}`);
     } catch (error) {
       alert('오류가 발생했습니다. 다시 시도해주세요.');
     }

--- a/dutchiepay/src/app/(routes)/community/write/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/write/[id]/page.jsx
@@ -1,14 +1,16 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { ALL_COMMUNITY_CATEGORIES } from '@/app/_util/constants';
 import FreePostForm from '@/app/_components/_community/_free/FreePostForm';
 import axios from 'axios';
 import getTextLength from '@/app/_util/getTextLength';
+import useFetchUpdatePostData from '@/app/hooks/useFetchUpdatePostData';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
-import { useState } from 'react';
 
 export default function MartModify() {
   const { id } = useParams();
@@ -17,9 +19,27 @@ export default function MartModify() {
   const router = useRouter();
   const [images, setImages] = useState([]);
   const [thumbnail, setThumbnail] = useState('');
+  const [post, setPost] = useState(null);
+  useFetchUpdatePostData({ id, setPost });
 
-  // 수정 페이지 내에서 데이터 호출 시 setValue 처리 필요
   const { register, watch, handleSubmit, setValue } = useForm();
+
+  useEffect(() => {
+    const handleSetValue = () => {
+      setEditorContent(JSON.parse(post.content));
+      setValue('title', post.title);
+      setValue(
+        'category',
+        Object.keys(ALL_COMMUNITY_CATEGORIES).find(
+          (key) => ALL_COMMUNITY_CATEGORIES[key] === post.category
+        )
+      );
+      setThumbnail(post.thumbnail);
+      setImages(post.images);
+    };
+
+    if (post) handleSetValue();
+  }, [post, setValue]);
 
   const onSubmit = async (formData) => {
     if (!formData.title || formData.title.length > 60) {
@@ -36,7 +56,7 @@ export default function MartModify() {
     }
 
     try {
-      await axios.post(
+      await axios.patch(
         `${process.env.NEXT_PUBLIC_BASE_URL}/free`,
         {
           freeId: id,
@@ -53,6 +73,8 @@ export default function MartModify() {
         }
       );
 
+      alert('정상적으로 수정되었습니다.');
+
       router.push(`/community/${id}`);
     } catch (error) {
       alert('오류가 발생했습니다. 다시 시도해주세요.');
@@ -66,6 +88,7 @@ export default function MartModify() {
           register={register}
           setValue={setValue}
           watch={watch}
+          editorContent={editorContent}
           setEditorContent={setEditorContent}
           setThumbnail={setThumbnail}
           thumbnail={thumbnail}

--- a/dutchiepay/src/app/(routes)/community/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/write/page.jsx
@@ -54,7 +54,6 @@ export default function CommunityWrite() {
 
       router.push(`/community/${response.data.freeId}`);
     } catch (error) {
-      console.log(error);
       alert('오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
@@ -66,6 +65,7 @@ export default function CommunityWrite() {
           register={register}
           setValue={setValue}
           watch={watch}
+          editorContent={editorContent}
           setEditorContent={setEditorContent}
           setThumbnail={setThumbnail}
           thumbnail={thumbnail}

--- a/dutchiepay/src/app/(routes)/community/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/write/page.jsx
@@ -52,7 +52,7 @@ export default function CommunityWrite() {
         }
       );
 
-      router.push(`/mart/${response.data.freeId}`);
+      router.push(`/community/${response.data.freeId}`);
     } catch (error) {
       console.log(error);
       alert('오류가 발생했습니다. 다시 시도해주세요.');

--- a/dutchiepay/src/app/(routes)/mart/detail/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/detail/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import PostContent from '@/app/_components/_community/PostContent';
+import PostContent from '@/app/_components/_community/_common/PostContent';
 import PostDetail from '@/app/_components/_community/PostDetail';
 import { useSearchParams } from 'next/navigation';
 

--- a/dutchiepay/src/app/(routes)/mart/write/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/write/page.jsx
@@ -81,6 +81,7 @@ export default function MartWrite() {
           register={register}
           setValue={setValue}
           watch={watch}
+          editorContent={setEditorContent}
           setEditorContent={setEditorContent}
           thumbnail={thumbnail}
           images={images}

--- a/dutchiepay/src/app/(routes)/used/detail/page.jsx
+++ b/dutchiepay/src/app/(routes)/used/detail/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import PostContent from '@/app/_components/_community/PostContent';
+import PostContent from '@/app/_components/_community/_common/PostContent';
 import PostDetail from '@/app/_components/_community/PostDetail';
 import { useSearchParams } from 'next/navigation';
 

--- a/dutchiepay/src/app/_components/_community/PostContent.jsx
+++ b/dutchiepay/src/app/_components/_community/PostContent.jsx
@@ -1,23 +1,21 @@
 'use client';
 
-import '@/styles/community.css';
-import '@/styles/globals.css';
-
-import CommentForm from './CommentForm';
+import { ALL_COMMUNITY_CATEGORIES } from '@/app/_util/constants';
+import CommentForm from './_free/CommentForm';
+import CurrentPost from './_local/CurrentPost';
+import DOMPurify from 'dompurify';
 import Image from 'next/image';
-import Post_Complete from '@/app/_components/_community/Post_Complete';
+import PostDetailAction from './_common/PostDetailAction';
+import { getPostDate } from '@/app/_util/getFormatDate';
 import prev from '/public/image/prev.svg';
-import profile from '/public/image/profile.jpg';
 import { useRouter } from 'next/navigation';
 
-export default function PostContent({ category, menu, isMyPostWritten }) {
+export default function PostContent({ menu, post, postId }) {
   const router = useRouter();
+  const cleanHtml = DOMPurify.sanitize(JSON.parse(post.content));
 
   return (
-    <section
-      className="min-h-[750px] w-[730px] px-[24px] py-[40px] border-r"
-      aria-labelledby="trade-post"
-    >
+    <section className="min-h-[750px] w-[730px] px-[24px] py-[40px] border-r">
       <div className="flex items-center justify-between">
         <Image
           src={prev}
@@ -29,67 +27,42 @@ export default function PostContent({ category, menu, isMyPostWritten }) {
           tabIndex="0"
         />
         <div className="w-[54px] py-[4px] bg-blue--500 text-white rounded-3xl flex justify-center">
-          {category}
+          {Object.keys(ALL_COMMUNITY_CATEGORIES).find(
+            (key) => ALL_COMMUNITY_CATEGORIES[key] === post.category
+          )}
         </div>
       </div>
       <article className="pl-[30px] pt-[24px]">
         <div className="flex justify-between items-center mb-[4px]">
           <div className="flex gap-[8px] items-center">
-            <Image
-              className="w-[40px] h-[40px] rounded-full border"
-              src={profile}
-              alt="프로필"
-              width={40}
-              height={40}
-            />
-            <strong>한유진님의 게시글</strong>
-          </div>
-          <p className="text-xs text-gray--500">조회수 100</p>
-        </div>
-        <h1 className="text-2xl text-blue--500 font-bold">
-          [사용감 적음!] 스탠드 선풍기🍃 팔아요
-        </h1>
-        <p className="inline-block min-h-[320px] mt-[24px]">
-          본가로 돌아가게 돼서 사용하던 선풍기 팔아요 작년 여름에 구매했고, 세척
-          한 번 한 상태입니다 원가 3만원인데 1만 5천원에 판매합니다 채팅으로
-          연락주세요 네고는 안 받습니다
-        </p>
-        <div className="flex justify-between">
-          <p className="text-xs text-gray--500">2024년 08월 07일 오후 09:07</p>
-          {isMyPostWritten && (
-            <div className="flex gap-[16px]">
-              <button className="text-sm text-gray--500 hover:underline">
-                수정하기
-              </button>
-              <button className="text-sm text-gray--500 hover:underline">
-                삭제하기
-              </button>
-            </div>
-          )}
-        </div>
-        {menu !== '커뮤니티' ? (
-          <div className="border rounded-lg px-[32px] py-[16px] mt-[24px]">
-            <div className="flex items-center gap-[4px] mb-[4px] pb-[4px] border-b-2 border-blue--500">
+            <div className="relative w-[40px] h-[40px] rounded-full border">
               <Image
-                className="w-[20px] h-[20px] rounded-full border"
-                src={profile}
-                alt="프로필"
-                width={20}
-                height={20}
+                className="w-[40px] h-[40px] rounded-full object-cover"
+                src={post.writerProfileImage}
+                alt={post.writer}
+                fill
               />
-              <h2 className="font-bold">한유진님의 최근 거래 완료글 (48개)</h2>
             </div>
-            <div className="flex flex-col gap-[8px] mt-[12px]">
-              <Post_Complete />
-              <Post_Complete />
-              <Post_Complete />
-              <Post_Complete />
-              <Post_Complete />
-            </div>
+            <strong>{post.writer}님의 게시글</strong>
           </div>
-        ) : (
-          <CommentForm />
-        )}
+          <p className="text-xs text-gray--500">조회수 {post.hit}</p>
+        </div>
+        <h1 className="text-2xl text-blue--500 font-bold">{post.title}</h1>
+        <p
+          className="inline-block min-h-[320px] mt-[24px]"
+          dangerouslySetInnerHTML={{ __html: cleanHtml }}
+        />
+        <div className="flex justify-between">
+          <p className="text-xs text-gray--500">
+            {getPostDate(post.createdAt)}
+          </p>
+          <PostDetailAction
+            postId={postId}
+            writerId={post.writerId}
+            menu={menu}
+          />
+        </div>
+        {menu !== 'community' ? <CurrentPost /> : <CommentForm />}
       </article>
     </section>
   );

--- a/dutchiepay/src/app/_components/_community/_common/PostContent.jsx
+++ b/dutchiepay/src/app/_components/_community/_common/PostContent.jsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ALL_COMMUNITY_CATEGORIES } from '@/app/_util/constants';
-import CommentForm from './_free/CommentForm';
-import CurrentPost from './_local/CurrentPost';
+import CommentForm from '@/app/_components/_community/_free/CommentForm';
+import CurrentPost from '@/app/_components/_community/_local/CurrentPost';
 import DOMPurify from 'dompurify';
 import Image from 'next/image';
-import PostDetailAction from './_common/PostDetailAction';
+import PostDetailAction from '@/app/_components/_community/_common/PostDetailAction';
 import { getPostDate } from '@/app/_util/getFormatDate';
 import prev from '/public/image/prev.svg';
 import { useRouter } from 'next/navigation';

--- a/dutchiepay/src/app/_components/_community/_common/PostDetailAction.jsx
+++ b/dutchiepay/src/app/_components/_community/_common/PostDetailAction.jsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import axios from 'axios';
+import { useRouter } from 'next/navigation';
+import { useSelector } from 'react-redux';
+
+export default function PostDetailAction({ postId, writerId, menu }) {
+  const userId = useSelector((state) => state.login.user.userId);
+  const access = useSelector((state) => state.login.access);
+  const router = useRouter();
+
+  const handlePostDelete = async () => {
+    if (
+      confirm('정말 삭제하시겠습니까?\n삭제된 게시글은 복구가 불가능합니다.')
+    ) {
+      try {
+        await axios.delete(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/free?freeId=${postId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${access}`,
+            },
+          }
+        );
+
+        alert('정상적으로 삭제되었습니다.');
+        router.push('/community');
+      } catch (error) {
+        if (error.response.data.message === '액세스 토큰이 만료되었습니다.') {
+          //
+        } else if (
+          error.response.data.message === '작성자가 일치하지 않습니다.'
+        ) {
+          alert('게시글 권한이 없습니다.');
+        } else {
+          alert('오류가 발생했습니다. 다시 시도해주세요.');
+        }
+      }
+    }
+  };
+
+  return (
+    <>
+      {writerId === userId && (
+        <div className="flex gap-[16px]">
+          <Link
+            className="text-sm text-gray--500 hover:underline"
+            href={`/${menu}/write/${postId}`}
+            role="button"
+          >
+            수정하기
+          </Link>
+          <button
+            className="text-sm text-gray--500 hover:underline"
+            onClick={handlePostDelete}
+          >
+            삭제하기
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_common/TextEditor.jsx
+++ b/dutchiepay/src/app/_components/_community/_common/TextEditor.jsx
@@ -28,6 +28,7 @@ const ReactQuill = dynamic(
 ReactQuill.displayName = 'ReactQuillComponent';
 
 export default function TextEditor({
+  editorContent,
   setEditorContent,
   setThumbnail,
   thumbnail,
@@ -149,6 +150,7 @@ export default function TextEditor({
       </div>
       <ReactQuill
         forwardedRef={quillRef}
+        value={editorContent}
         onChange={handleContentChange}
         theme="snow"
         modules={modules}

--- a/dutchiepay/src/app/_components/_community/_free/Comment.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/Comment.jsx
@@ -2,7 +2,7 @@ import '@/styles/community.css';
 import '@/styles/globals.css';
 
 import Image from 'next/image';
-import Reply from '../Reply';
+import Reply from '@/app/_components/_community/_free/Reply';
 import profile from '/public/image/otherProfile.jpg';
 import reply from '/public/image/community/reply.svg';
 import { useState } from 'react';

--- a/dutchiepay/src/app/_components/_community/_free/CommentForm.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/CommentForm.jsx
@@ -2,7 +2,7 @@
 
 import '@/styles/globals.css';
 
-import Comment from '@/app/_components/_community/_local/Comment';
+import Comment from '@/app/_components/_community/_free/Comment';
 import Image from 'next/image';
 import PostCommentAction from './PostCommentAction';
 import axios from 'axios';

--- a/dutchiepay/src/app/_components/_community/_free/FreePostForm.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/FreePostForm.jsx
@@ -7,6 +7,7 @@ export default function FreePostForm({
   register,
   setValue,
   watch,
+  editorContent,
   setEditorContent,
   thumbnail,
   images,
@@ -23,6 +24,7 @@ export default function FreePostForm({
       />
       <TitleInput register={register} />
       <TextEditor
+        editorContent={editorContent}
         setEditorContent={setEditorContent}
         thumbnail={thumbnail}
         images={images}

--- a/dutchiepay/src/app/_components/_community/_free/Post_Hot.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/Post_Hot.jsx
@@ -3,8 +3,8 @@ import '@/styles/globals.css';
 
 import Image from 'next/image';
 import Link from 'next/link';
-import comment from '../../../../public/image/comment.svg';
-import profile from '../../../../public/image/profile.jpg';
+import comment from '/public/image/comment.svg';
+import profile from '/public/image/profile.jpg';
 
 export default function Post_Hot({ index }) {
   return (

--- a/dutchiepay/src/app/_components/_community/_free/Post_Similar.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/Post_Similar.jsx
@@ -3,8 +3,8 @@ import '@/styles/globals.css';
 
 import Image from 'next/image';
 import Link from 'next/link';
-import comment from '../../../../public/image/comment.svg';
-import profile from '../../../../public/image/profile.jpg';
+import comment from '/public/image/comment.svg';
+import profile from '/public/image/profile.jpg';
 
 export default function Post_Similar() {
   return (

--- a/dutchiepay/src/app/_components/_community/_local/CurrentPost.jsx
+++ b/dutchiepay/src/app/_components/_community/_local/CurrentPost.jsx
@@ -1,0 +1,27 @@
+import Image from 'next/image';
+import Post_Complete from '../Post_Complete';
+import profile from '/public/image/profile.jpg';
+
+export default function CurrentPost({ register, setValue }) {
+  return (
+    <div className="border rounded-lg px-[32px] py-[16px] mt-[24px]">
+      <div className="flex items-center gap-[4px] mb-[4px] pb-[4px] border-b-2 border-blue--500">
+        <Image
+          className="w-[20px] h-[20px] rounded-full border"
+          src={profile}
+          alt="프로필"
+          width={20}
+          height={20}
+        />
+        <h2 className="font-bold">한유진님의 최근 거래 완료글 (48개)</h2>
+      </div>
+      <div className="flex flex-col gap-[8px] mt-[12px]">
+        <Post_Complete />
+        <Post_Complete />
+        <Post_Complete />
+        <Post_Complete />
+        <Post_Complete />
+      </div>
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_util/getFormatDate.js
+++ b/dutchiepay/src/app/_util/getFormatDate.js
@@ -41,4 +41,25 @@ const calculateTimeUnits = (distance) => {
   };
 };
 
-export { getFormatDate, getRemainingTime };
+const getPostDate = (dateString) => {
+  const date = new Date(dateString);
+
+  const options = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  };
+
+  const formatter = new Intl.DateTimeFormat('ko-KR', options);
+  const formattedDate = formatter.format(date);
+
+  const [year, month, day, hour, minute] = formattedDate.split(/[^0-9]+/);
+  const ampm = date.getHours() >= 12 ? '오후' : '오전';
+
+  return `${year}년 ${month}월 ${day}일 ${ampm} ${hour}:${minute}`;
+};
+
+export { getFormatDate, getRemainingTime, getPostDate };

--- a/dutchiepay/src/app/hooks/useFetchUpdatePostData.jsx
+++ b/dutchiepay/src/app/hooks/useFetchUpdatePostData.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+
+import axios from 'axios';
+import useReissueToken from './useReissueToken';
+import { useRouter } from 'next/navigation';
+import { useSelector } from 'react-redux';
+
+export default function useFetchUpdatePostData({ id, setPost }) {
+  const access = useSelector((state) => state.login.access);
+  const router = useRouter();
+  const hasFetched = useRef(false);
+
+  const { refreshAccessToken } = useReissueToken();
+  useEffect(() => {
+    const fetchProduct = async () => {
+      if (hasFetched.current) return;
+
+      hasFetched.current = true;
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/free/${id}`,
+          {
+            headers: {
+              Authorization: `Bearer ${access}`,
+            },
+          }
+        );
+        setPost(response.data);
+      } catch (error) {
+        if (error.response.data.message === '작성자가 일치하지 않습니다.') {
+          alert('게시글의 권한이 없습니다. 메인으로 돌아갑니다.');
+          router.push('/');
+        } else if (
+          error.response.data.message === '액세스 토큰이 만료되었습니다.'
+        ) {
+          hasFetched.current = false;
+          const reissueResponse = await refreshAccessToken();
+          if (reissueResponse.success) {
+            await fetchProduct();
+          } else {
+            alert(
+              reissueResponse.message ||
+                '오류가 발생했습니다. 다시 시도해주세요.'
+            );
+          }
+        } else {
+          console.log(error);
+          alert('오류가 발생했습니다. 다시 시도해주세요.');
+        }
+      }
+    };
+
+    if (id) fetchProduct();
+  }, [id, setPost, access, router, refreshAccessToken]);
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/mart-write-api -> main

## 변경 사항
1. 커뮤니티 상세페이지 동적 라우팅으로 변경
2. 상세페이지 접근 시 상세페이지 API 호출 및 데이터 바인딩
3. HTML 렌더링 과정 중 XSS 공격 방지를 위해 dompurity 적용
4. PostContent를 지역/자유 게시판 모두 활용할 수 있고 변경된 API에 맞춰 수정
5. 게시글 수정 및 삭제 actions 처리
6. 수정 페이지 접근 시 게시글 데이터를 받아올 수 있는 custom hook을 구현, 지역/자유 게시판 모두 가능하도록 처리
7. 자유게시판 수정 페이지 접근 시 form 데이터 set 처리
8. content 수정 값 set을 위해 react quill value 설정
9. 게시글 작성 시간 표시를 위한 getPostDate 추가 -> 추후 게시글 작성 시 사용되는 함수와 통합 PR 올릴 예정
10. 

## 테스트 결과
![스크린샷 2024-12-11 174233](https://github.com/user-attachments/assets/03dd8f2a-c6a1-413d-8c7f-7b003442ae08)
![image](https://github.com/user-attachments/assets/b32623dc-2e4b-4413-a4a8-602f6c0b7499)

## ETC

