### PR TITLE
[Feat] 상품/커뮤니티 검색 목록 

### DIFF
--- a/dutchiepay/src/app/(routes)/community/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/page.jsx
@@ -3,6 +3,7 @@
 import CommunityPostList from '@/app/_components/_community/CommunityPostList';
 import FreeCommunityFilter from '@/app/_components/_community/_free/FreeCommunityFilter';
 import Link from 'next/link';
+import PostSearch from '@/app/_components/_community/_common/PostSearch';
 import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
 import { useState } from 'react';
@@ -10,12 +11,14 @@ import { useState } from 'react';
 export default function Community() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const params = useSearchParams();
-
   const [filter, setFilter] = useState('최신순');
   const category = params.get('category');
+  const [keyword, setKeyword] = useState('');
+
   return (
     <section className="min-h-[750px] w-[1020px] mb-[100px]">
-      <div className="mt-[60px] flex justify-end items-end">
+      <div className="mt-[60px] flex justify-between items-end">
+        <PostSearch setKeyword={setKeyword} />
         <div className="flex items-end gap-[24px]">
           <FreeCommunityFilter filter={filter} setFilter={setFilter} />
           <Link
@@ -32,6 +35,7 @@ export default function Community() {
         filter={filter}
         setFilter={setFilter}
         category={category}
+        keyword={keyword}
       />
     </section>
   );

--- a/dutchiepay/src/app/(routes)/mart/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/page.jsx
@@ -2,17 +2,21 @@
 
 import Link from 'next/link';
 import MartPostList from '@/app/_components/_community/_local/MartPostList';
+import PostSearch from '@/app/_components/_community/_common/PostSearch';
 import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
+import { useState } from 'react';
 
 export default function Mart() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const params = useSearchParams();
   const category = params.get('category');
+  const [keyword, setKeyword] = useState('');
 
   return (
-    <main className="min-h-[750px] w-[1020px] mb-[100px]">
-      <div className="mt-[60px] flex justify-end">
+    <section className="min-h-[750px] w-[1020px] mb-[100px]">
+      <div className="mt-[60px] flex justify-between">
+        <PostSearch setKeyword={setKeyword} />
         <Link
           href={`${isLoggedIn ? '/mart/write' : '/login'}`}
           className="text-white rounded bg-blue--500 px-[16px] py-[8px] text-sm"
@@ -21,7 +25,7 @@ export default function Mart() {
           게시글 작성
         </Link>
       </div>
-      <MartPostList category={category} />
-    </main>
+      <MartPostList category={category} keyword={keyword} />
+    </section>
   );
 }

--- a/dutchiepay/src/app/(routes)/search/page.jsx
+++ b/dutchiepay/src/app/(routes)/search/page.jsx
@@ -35,7 +35,7 @@ export default function Search() {
         <ProductFilter filter={filter} setFilter={setFilter} />
       </div>
 
-      {isInitialized && products.length > 0 ? (
+      {isInitialized && products.length > 0 && keyword ? (
         <article className="mt-[24px] grid grid-cols-4 gap-8">
           {products.map((item, key) => (
             <Product key={key} product={item} />

--- a/dutchiepay/src/app/(routes)/search/page.jsx
+++ b/dutchiepay/src/app/(routes)/search/page.jsx
@@ -1,17 +1,26 @@
 'use client';
 
-import Product_Like from '@/app/_components/Product';
+import { FILTERS } from '@/app/_util/constants';
+import Product from '@/app/_components/Product';
+import ProductFilter from '@/app/_components/_commerce/_product/ProductFilter';
 import SearchContainer from '@/app/_components/_search/SearchContainer';
 import SearchEmpty from '@/app/_components/_search/SearchEmpty';
+import useInfiniteScroll from '@/app/hooks/useInfiniteScroll';
 import { useState } from 'react';
 
 export default function Search() {
   const [keyword, setKeyword] = useState('');
-  const [hasCommerce, setHasCommerce] = useState(false); // 검색 결과 존재 여부
+  const [filter, setFilter] = useState('최신순');
+  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/search/commerce?keyword=${keyword}&filter=${FILTERS[filter]}&end=1&limit=16`;
+  const {
+    items: products,
+    isInitialized,
+    lastItemRef,
+  } = useInfiniteScroll({ fetchUrl });
 
   return (
     <section className="min-h-[750px] w-[1020px] mb-[100px]">
-      <article className="flex flex-col items-center justify-center mt-[60px] mx-auto">
+      <article className="flex flex-col items-center justify-center mt-[60px] mx-auto z-10">
         <h1 className="font-bold text-4xl">상품 검색</h1>
         <small className="mt-[4px] mb-[24px] text-sm">
           더취페이에서 판매하는 공동구매 상품들을 검색할 수 있어요
@@ -19,17 +28,19 @@ export default function Search() {
         <SearchContainer keyword={keyword} setKeyword={setKeyword} />
       </article>
 
-      <h2 className="mt-[60px] text-2xl font-bold">
-        &apos;{keyword ? keyword : '검색어 없음'}&apos;&nbsp;에 대한 검색결과
-      </h2>
-      {hasCommerce ? (
-        <article className="mt-[24px]">
-          <div className="flex justify-between mt-[12px] px-[12px]">
-            <Product_Like />
-            <Product_Like />
-            <Product_Like />
-            <Product_Like />
-          </div>
+      <div className="flex justify-between items-end">
+        <h2 className="mt-[60px] text-2xl font-bold">
+          &apos;{keyword ? keyword : '검색어 없음'}&apos;&nbsp;에 대한 검색결과
+        </h2>
+        <ProductFilter filter={filter} setFilter={setFilter} />
+      </div>
+
+      {isInitialized && products.length > 0 ? (
+        <article className="mt-[24px] grid grid-cols-4 gap-8">
+          {products.map((item, key) => (
+            <Product key={key} product={item} />
+          ))}
+          <div ref={lastItemRef}></div>
         </article>
       ) : (
         <SearchEmpty keyword={keyword} />

--- a/dutchiepay/src/app/_components/Product.jsx
+++ b/dutchiepay/src/app/_components/Product.jsx
@@ -40,10 +40,10 @@ export default function Product({ product }) {
               {product.discountPercent}%
             </p>
             <p className="text-[12px] text-gray--500 line-through">
-              {product.originalPrice?.toLocaleString('ko-KR')}원
+              {product.productPrice?.toLocaleString('ko-KR')}원
             </p>
             <strong className="text-[16px]">
-              {product.salePrice?.toLocaleString('ko-KR')}원
+              {product.discountPrice?.toLocaleString('ko-KR')}원
             </strong>
           </div>
 

--- a/dutchiepay/src/app/_components/Product.jsx
+++ b/dutchiepay/src/app/_components/Product.jsx
@@ -14,7 +14,7 @@ export default function Product({ product }) {
           href={`/commerce/${product.buyId}`}
           className="w-[220px] flex flex-col gap-[4px]"
         >
-          <div className="w-full h-[148px] relative overflow-hidden">
+          <div className="w-full h-[148px] relative overflow-hidden z-10">
             <Image
               className={`w-full h-[148px] transform transition-transform duration-300 hover:scale-110 object-cover ${product.expireDate < 0 ? 'grayscale-[65%]' : ''}`}
               src={product.productImg}
@@ -40,10 +40,10 @@ export default function Product({ product }) {
               {product.discountPercent}%
             </p>
             <p className="text-[12px] text-gray--500 line-through">
-              {product.originalPrice.toLocaleString('ko-KR')}원
+              {product.originalPrice?.toLocaleString('ko-KR')}원
             </p>
             <strong className="text-[16px]">
-              {product.salePrice.toLocaleString('ko-KR')}원
+              {product.salePrice?.toLocaleString('ko-KR')}원
             </strong>
           </div>
 

--- a/dutchiepay/src/app/_components/_community/CommunityPostList.jsx
+++ b/dutchiepay/src/app/_components/_community/CommunityPostList.jsx
@@ -7,10 +7,10 @@ import Link from 'next/link';
 import post from '/public/image/community/post.svg';
 import useInfiniteScroll from '@/app/hooks/useInfiniteScroll';
 
-export default function CommunityPostList({ category, filter }) {
+export default function CommunityPostList({ category, filter, keyword }) {
   const categoryParam = category ? `category=${category}&` : '';
   const filterParam = COMMUNITY_FILTER[filter];
-  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/free/list?${categoryParam}filter=${filterParam}&limit=16`;
+  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/free/list?${categoryParam}filter=${filterParam}&limit=16&word=${keyword}`;
   const {
     items: posts,
     isInitialized,

--- a/dutchiepay/src/app/_components/_community/_common/PostContent.jsx
+++ b/dutchiepay/src/app/_components/_community/_common/PostContent.jsx
@@ -10,18 +10,10 @@ import { getPostDate } from '@/app/_util/getFormatDate';
 import prev from '/public/image/prev.svg';
 import profile from '/public/image/profile.jpg';
 import { useRouter } from 'next/navigation';
-import useInfiniteScroll from '@/app/hooks/useInfiniteScroll';
 
 export default function PostContent({ menu, post, postId }) {
   const router = useRouter();
   const cleanHtml = DOMPurify.sanitize(JSON.parse(post.content));
-  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/free/comments/list?freeId=${postId}&limit=6`;
-  const {
-    items: comments,
-    isInitialized,
-    lastItemRef,
-    refresh: refreshComments,
-  } = useInfiniteScroll({ fetchUrl });
 
   return (
     <section className="min-h-[750px] w-[730px] px-[24px] py-[40px] border-r">
@@ -78,14 +70,7 @@ export default function PostContent({ menu, post, postId }) {
             writerProfileImage={post.writerProfileImage}
           />
         ) : (
-          <CommentForm
-            postId={postId}
-            post={post}
-            isInitialized={isInitialized}
-            comments={comments}
-            refreshComments={refreshComments}
-            lastItemRef={lastItemRef}
-          />
+          <CommentForm postId={postId} post={post} />
         )}
       </article>
     </section>

--- a/dutchiepay/src/app/_components/_community/_common/PostSearch.jsx
+++ b/dutchiepay/src/app/_components/_community/_common/PostSearch.jsx
@@ -1,0 +1,21 @@
+import Image from 'next/image';
+import search from '/public/image/search.svg';
+
+export default function PostSearch({ setKeyword }) {
+  return (
+    <div className="relative">
+      <input
+        className="w-[300px] border pl-[32px] pr-[4px] py-[8px] text-sm outline-none"
+        placeholder="게시글 제목으로 검색"
+        onChange={(e) => setKeyword(e.target.value)}
+      />
+      <Image
+        className="absolute top-[11px] left-[10px]"
+        src={search}
+        alt="search"
+        width={15}
+        height={15}
+      />
+    </div>
+  );
+}

--- a/dutchiepay/src/app/_components/_community/_free/CommentForm.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/CommentForm.jsx
@@ -2,22 +2,22 @@
 
 import '@/styles/globals.css';
 
+import CommentWrite from './CommentWrite';
+import FreeCommentList from './FreeCommentList';
 import Image from 'next/image';
+import communityComment from '/public/image/community/communityComment.svg';
 import profile from '/public/image/profile.jpg';
+import useInfiniteScroll from '@/app/hooks/useInfiniteScroll';
 import { useSelector } from 'react-redux';
 
-import FreeCommentList from './FreeCommentList';
-import CommentWrite from './CommentWrite';
-import communityComment from '/public/image/community/communityComment.svg';
-
-const CommentForm = ({
-  postId,
-  post,
-  isInitialized,
-  comments,
-  refreshComments,
-  lastItemRef,
-}) => {
+const CommentForm = ({ postId, post }) => {
+  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/free/comments/list?freeId=${postId}&limit=6`;
+  const {
+    items: comments,
+    isInitialized,
+    lastItemRef,
+    refresh: refreshComments,
+  } = useInfiniteScroll({ fetchUrl });
   const profileImage = useSelector((state) => state.login.user.profileImage);
 
   return (
@@ -26,14 +26,15 @@ const CommentForm = ({
         <h2 className="text-xl font-bold">댓글</h2>
         <p>{post.commentsCount}개</p>
       </div>
-      <div className="flex gap-[12px] my-[12px]">
-        <Image
-          className="w-[50px] h-[50px] rounded-full border"
-          src={profileImage || profile}
-          alt="프로필"
-          width={50}
-          height={50}
-        />
+      <div className="flex justify-between my-[12px]">
+        <div className="relative w-[50px] h-[50px] rounded-full border">
+          <Image
+            className="w-[50px] h-[50px] rounded-full object-cover"
+            src={profileImage || profile}
+            alt="프로필"
+            fill
+          />
+        </div>
         <CommentWrite
           postId={postId}
           refreshComments={refreshComments}
@@ -45,15 +46,15 @@ const CommentForm = ({
           <Image
             src={communityComment}
             alt="등록된 댓글이 없습니다."
-            width={60}
-            height={60}
-            className="mt-[15%] pb-[30px] mx-auto"
+            width={58}
+            height={58}
+            className="mt-[60px] mb-[12px] mx-auto"
           />
-          <strong className="text-l text-center mb-[50px]">
+          <p className="text-sm text-center mb-[50px]">
             현재 등록된 댓글이 없습니다.
             <br />
             새로운 댓글을 작성하여 다양한 의견과 정보를 공유해 주세요.
-          </strong>
+          </p>
         </div>
       ) : (
         <div className="border-b py-[16px]">

--- a/dutchiepay/src/app/_components/_community/_free/CommentWrite.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/CommentWrite.jsx
@@ -56,7 +56,7 @@ export default function CommentWrite({ postId, refreshComments }) {
     }
   };
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="w-full">
+    <form onSubmit={handleSubmit(onSubmit)} className="w-[580px]">
       <div className="flex flex-col border border-gray--300 rounded-lg p-2 bg-white">
         <textarea
           id="comment"

--- a/dutchiepay/src/app/_components/_community/_free/FreeCommentList.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/FreeCommentList.jsx
@@ -1,14 +1,15 @@
+import { useCallback, useRef, useState } from 'react';
+
 import Image from 'next/image';
-import ReplyList from '@/app/_components/_community/_free/ReplyList';
-import reply from '/public/image/community/reply.svg';
-import { useEffect, useRef, useState, useCallback } from 'react';
-import axios from 'axios';
-import { useSelector } from 'react-redux';
-import useReissueToken from '@/app/hooks/useReissueToken';
-import profile from '/public/image/profile.jpg';
 import ReplyForm from './ReplyForm';
+import ReplyList from '@/app/_components/_community/_free/ReplyList';
 import RootCommentInfo from './RootCommentInfo';
+import axios from 'axios';
+import profile from '/public/image/profile.jpg';
+import reply from '/public/image/community/reply.svg';
 import trash from '/public/image/trash.svg';
+import useReissueToken from '@/app/hooks/useReissueToken';
+import { useSelector } from 'react-redux';
 
 export default function FreeCommentList({
   item,
@@ -66,7 +67,7 @@ export default function FreeCommentList({
   return (
     <div className="flex items-start mb-[20px] gap-[4px]">
       <Image
-        className="border rounded-full "
+        className="border rounded-full"
         src={
           item.nickname === null && item.contents === '삭제된 댓글입니다.'
             ? trash
@@ -94,7 +95,7 @@ export default function FreeCommentList({
                 hasFetched.current = true;
                 setHasViewedReplies(true);
               }}
-              className="text-sm mb-[5px] text-blue--500"
+              className="text-sm mb-[5px] text-blue--500 hover:underline"
             >
               답글 보기
             </button>

--- a/dutchiepay/src/app/_components/_community/_local/MartPostList.jsx
+++ b/dutchiepay/src/app/_components/_community/_local/MartPostList.jsx
@@ -4,9 +4,9 @@ import MartPostItem from './MartPostItem';
 import post from '/public/image/community/post.svg';
 import useInfiniteScroll from '@/app/hooks/useInfiniteScroll';
 
-export default function MartPostList({ category }) {
+export default function MartPostList({ category, keyword }) {
   const categoryParam = category ? `category=${category}&` : '';
-  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/mart/list?${categoryParam}limit=16`;
+  const fetchUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/mart/list?${categoryParam}limit=16&word=${keyword}`;
   const {
     items: posts,
     isInitialized,

--- a/dutchiepay/src/app/_components/_layout/Header.jsx
+++ b/dutchiepay/src/app/_components/_layout/Header.jsx
@@ -5,7 +5,7 @@ import HeaderTop from './HeaderTop';
 
 export default function Header() {
   return (
-    <header className="fixed h-[105px] top-0 left-0 right-0 z-20 w-full bg-white shadow">
+    <header className="fixed h-[105px] top-0 left-0 right-0 z-30 w-full bg-white shadow">
       <div className=" mx-auto w-[1020px]">
         <HeaderTop />
         <HeaderMain />

--- a/dutchiepay/src/app/_components/_layout/HeaderTop.jsx
+++ b/dutchiepay/src/app/_components/_layout/HeaderTop.jsx
@@ -28,8 +28,8 @@ export default function HeaderTop() {
             </button>
           </li>
           <li className="header-nav-item">
-            <Link href="/mypage/myorder" className="text-xs hover:underline">
-              주문/배송
+            <Link href="/mypage" className="text-xs hover:underline">
+              마이페이지
             </Link>
           </li>
           <li className="header-nav-item">

--- a/dutchiepay/src/app/_components/_search/SearchContainer.jsx
+++ b/dutchiepay/src/app/_components/_search/SearchContainer.jsx
@@ -56,7 +56,7 @@ export default function SearchContainer({ keyword, setKeyword }) {
   }, []);
 
   return (
-    <div ref={divRef}>
+    <div ref={divRef} className="z-20">
       <SearchInput
         setIsFocus={setIsFocus}
         searchHistory={searchHistory}

--- a/dutchiepay/src/app/hooks/useInfiniteScroll.jsx
+++ b/dutchiepay/src/app/hooks/useInfiniteScroll.jsx
@@ -32,7 +32,6 @@ const useInfiniteScroll = ({ fetchUrl }) => {
         if (response.data.cursor === null) setHasMore(false);
         setCursor(response.data.cursor);
         setIsInitialized(true);
-        console.log(response.data.products);
         return (
           response.data.posts ||
           response.data.products ||
@@ -40,7 +39,6 @@ const useInfiniteScroll = ({ fetchUrl }) => {
           []
         );
       } catch (error) {
-        console.log(error);
         if (error.response.data.message === '액세스 토큰이 만료되었습니다.') {
           hasFetched.current = false;
           const reissueResponse = await refreshAccessToken();
@@ -52,6 +50,10 @@ const useInfiniteScroll = ({ fetchUrl }) => {
                 '오류가 발생했습니다. 다시 시도해주세요.'
             );
           }
+        } else if (
+          error.response.data.message === '검색어가 입력되지 않았습니다.'
+        ) {
+          return [];
         } else {
           alert('오류가 발생했습니다. 다시 시도해주세요.');
         }

--- a/dutchiepay/src/app/hooks/useInfiniteScroll.jsx
+++ b/dutchiepay/src/app/hooks/useInfiniteScroll.jsx
@@ -32,6 +32,7 @@ const useInfiniteScroll = ({ fetchUrl }) => {
         if (response.data.cursor === null) setHasMore(false);
         setCursor(response.data.cursor);
         setIsInitialized(true);
+        console.log(response.data.products);
         return (
           response.data.posts ||
           response.data.products ||
@@ -40,7 +41,6 @@ const useInfiniteScroll = ({ fetchUrl }) => {
         );
       } catch (error) {
         console.log(error);
-
         if (error.response.data.message === '액세스 토큰이 만료되었습니다.') {
           hasFetched.current = false;
           const reissueResponse = await refreshAccessToken();


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/search-list -> main

## 변경 사항
1. 상품 검색 결과 출력
2. 검색 결과 컴포넌트 Image 요소에 의한 z-index 변경
3. 커뮤니티 검색을 위해 PostSearch 구현

## 테스트 결과
※ 현재 API 명세서와 가격 변수명이 달라 수정 요청 드렸습니다. (이전 컴포넌트 재사용이라 다른 API와 변수명이 달라서 백엔드에서 변경해야 함)
![스크린샷 2024-12-22 210622](https://github.com/user-attachments/assets/ae302e31-9e6d-4368-bc9f-182b1aa4bac0)
※ 해당 이미지에서 검색어 없음으로 표시되는 이유는 현재 ""가 전달될 경우, 모든 값이 반환되고 있어서 수정 요청드렸습니다. 필터링 체크를 위해 해당 출력으로 테스트했고 프론트에서도 검색어가 ""일 경우에는 검색결과 없음이 표시되도록 작업해두었습니다.
![스크린샷 2024-12-22 211020](https://github.com/user-attachments/assets/74d22fb0-a90d-4cca-832d-58d1876ea673)
![스크린샷 2024-12-22 212719](https://github.com/user-attachments/assets/c232826d-abbc-45fe-ac61-40db688fc160)
![스크린샷 2024-12-22 212723](https://github.com/user-attachments/assets/de568040-f0a1-4702-abf0-a6b46b77281e)
![스크린샷 2024-12-22 212728](https://github.com/user-attachments/assets/78ecf00c-7788-4d01-b1d9-86ed5ac47fb1)


## ETC
onChange마다 요청이 들어가도록 설정되었습니다. 무한스크롤 자체 구현이 그렇게 설정되어 있어서 해당 부분 성능 강화를 위해서는 onChange 시에 바로바로 set되는 것이 아닌 디바운스로 일정 시간 뒤에 set되도록 설정해주면 되나 별도 라이브러리가 필요하고 현재 기능 동작 구현이 우선이라 생각해서 추후 필요하다고 판단되면 추가할 예정입니다.