### PR TITLE
[feat] 붙여넣기한 base64 이미지를 S3에 업로드하여 대체

### DIFF
--- a/dutchiepay/src/app/_util/getBase64File.js
+++ b/dutchiepay/src/app/_util/getBase64File.js
@@ -1,0 +1,22 @@
+export default function getBase64File(base64String) {
+  return new Promise((resolve, reject) => {
+    try {
+      const arr = base64String.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const data = atob(arr[1]);
+      let uInt8Array = new Uint8Array(data.length);
+
+      for (let i = 0; i < data.length; i++) {
+        uInt8Array[i] = data.charCodeAt(i);
+      }
+
+      const file = new File([uInt8Array], `image_${new Date().getTime()}`, {
+        type: mime,
+      });
+      resolve(file);
+    } catch (error) {
+      alert('Base64 문자열 변환에 실패했습니다. 다시 시도해주세요.');
+      reject(error);
+    }
+  });
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/paste-image -> main

## 변경 사항
붙여넣기한 이미지를 base64에서 File 객체로 변환한 뒤, S3에 업로드 하여 반환된 URL로 대치

## 테스트 결과
붙여넣기한 이미지 이미지 목록에 사용 가능
![스크린샷 2024-12-24 175751](https://github.com/user-attachments/assets/eb0634a3-524d-4450-88b8-01fbab36c69c)


## ETC
이전에 회의에서 붙여넣기한 이미지를 사용하지 않도록 하고자 하였으나 사용성이 너무 떨어질 것 같고, React quill에서 이미지를 base64 형식으로 이용한다고 하고 대부분의 레퍼런스에서 base64 처리만 해주는 걸로 보아 걱정했던 오류가 없을 것으로 판단했습니다.
