### PR TITLE
[fix] 마이페이지 활동내역 UI 수정

### DIFF
--- a/dutchiepay/src/app/(routes)/mypage/mypost/page.jsx
+++ b/dutchiepay/src/app/(routes)/mypage/mypost/page.jsx
@@ -101,7 +101,7 @@ export default function MyPost() {
           </div>
         ) : (
           posts.map((item, index) => {
-            return <MyPostList key={index} item={item} />;
+            return <MyPostList key={index} item={item} filter={filter} />;
           })
         )}
         {posts.length > 0 && (

--- a/dutchiepay/src/app/_components/_mypage/MyPostList.jsx
+++ b/dutchiepay/src/app/_components/_mypage/MyPostList.jsx
@@ -9,11 +9,11 @@ import mart from '/public/image/mart.jpg';
 import profile from '/public/image/profile.jpg';
 import community from '/public/image/community.jpg';
 import { ALL_COMMUNITY_CATEGORIES } from '@/app/_util/constants';
-export default function MyPostList({ item }) {
+export default function MyPostList({ item, filter }) {
   return (
     <Link
       href={`/mart/detail?postId=${item.postId}`}
-      className="w-[220px] flex flex-col gap-[4px] cursor-pointer"
+      className="w-[220px]  flex flex-col gap-[4px] cursor-pointer"
     >
       <div className="w-full h-[148px] relative overflow-hidden">
         {item.category == '마트/배달' ? (
@@ -37,9 +37,11 @@ export default function MyPostList({ item }) {
         <p className="text-blue--500 text-sm font-semibold">
           {item.category === '마트/배달'
             ? item.category
-            : Object.keys(ALL_COMMUNITY_CATEGORIES).find(
-                (key) => ALL_COMMUNITY_CATEGORIES[key] === item.category
-              )}
+            : filter === '작성한 게시글'
+              ? item.category
+              : Object.keys(ALL_COMMUNITY_CATEGORIES).find(
+                  (key) => ALL_COMMUNITY_CATEGORIES[key] === item.category
+                )}
         </p>
         {item.category !== '마트/배달' ? (
           <div className="flex items-center gap-[8px]">
@@ -55,7 +57,7 @@ export default function MyPostList({ item }) {
       </div>
 
       <strong className="mt-[4px] title--multi-line">{item.title}</strong>
-      <p className="text-xs text-gray--500 title--multi-line title--multi-line-3 mt-[4px] mb-[8px]">
+      <p className="min-h-[45px]  text-xs text-gray--500 title--multi-line title--multi-line-3 mt-[4px] mb-[8px]">
         {item.description}
       </p>
       <div className="w-full flex justify-between items-center">


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
ex)  fix/mypost-UI-> main

## 변경 사항
마이페이지 활동 내역 UI description 부분 동일한 크기로 UI 수정했습니다.
## 테스트 결과
![image](https://github.com/user-attachments/assets/534055a5-7ab4-4af1-815e-ea97706d0155)


## ETC
html태그는 벡엔드에서 수정해서 넘겨주기로 했고 댓글 남긴 게시글 또한 API 반환값 이상으로 확인되어 벡엔드에 수정요청 드렸습니다
