### PR TITLE
[fix] n줄 이상 댓글 작성 시 UI 오류 해결, 댓/답글 영역 padding이 적용되지 않는 현상 및 line-height 통일되지 않는 오류 해결

### DIFF
--- a/dutchiepay/src/app/_components/_community/_free/_comment/FreeCommentList.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/_comment/FreeCommentList.jsx
@@ -82,7 +82,7 @@ export default function FreeCommentList({
               fill
             />
           </div>
-          <div className="grow">
+          <div className="w-[600px]">
             {postId && (
               <RootCommentInfo
                 item={item}

--- a/dutchiepay/src/app/_components/_community/_free/_comment/ReplyList.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/_comment/ReplyList.jsx
@@ -59,7 +59,9 @@ export default function ReplyList({
                   ? item.mentionedNickname
                   : '탈퇴한 사용자'}
               </span>
-              <span className="text-sm px-[12px]">{item.contents}</span>
+              <span className="text-sm px-[12px] leading-relaxed">
+                {item.contents}
+              </span>
             </p>
           )}
         </div>

--- a/dutchiepay/src/app/_components/_community/_free/_comment/RootCommentInfo.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/_comment/RootCommentInfo.jsx
@@ -26,7 +26,7 @@ export default function RootCommentInfo({
           refreshComments={refreshComments}
         />
       ) : (
-        <span className="text-sm px-[12px]">{item.contents}</span>
+        <p className="text-sm ml-[12px] leading-relaxed">{item.contents}</p>
       )}
     </>
   );


### PR DESCRIPTION

# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/comment -> main

## 변경 사항
1. 댓글 영역이 댓글 글자수가 늘어남에 따라 width가 계속해서 커지는 현상 해결
2. 댓글 span 태그에 padding이 영향을 받지 않아 발생하는 UI 오류 해결
3. 댓글 contents를 p 태그로 변경함에 따라 발생하는 댓글과 답글의 line-height가 다르게 표시되지 않도록 글꼴 크기로 line-height 동기화

## 테스트 결과
![스크린샷 2025-01-04 141023](https://github.com/user-attachments/assets/4cc4de92-6eaf-4374-bde5-f206f10c6644)


## ETC
