### PR TITLE
[fix] 후기 작성 시 주문 내역 refresh 및 후기 작성된 주문 내역 문의 버튼이 2개 뜨는 오류 수정

### DIFF
--- a/dutchiepay/src/app/_components/_mypage/_order/OrderActionButton.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_order/OrderActionButton.jsx
@@ -33,7 +33,8 @@ export default function OrderActionButton({ product, setStatus, status }) {
         >
           환불/교환
         </button>
-      ) : status === '구매확정' || status === '공구진행중' ? (
+      ) : (status === '구매확정' && !product.hasReviewed) ||
+        status === '공구진행중' ? (
         <button
           className="text-blue-500 text-sm border border-blue--500 rounded px-[56px] py-[8px]"
           onClick={() =>

--- a/dutchiepay/src/app/_components/_mypage/_order/OrderList.jsx
+++ b/dutchiepay/src/app/_components/_mypage/_order/OrderList.jsx
@@ -98,7 +98,10 @@ export default function OrderList({
 
   useEffect(() => {
     const handleMessage = (event) => {
-      if (event.data.type === 'REFUND/EXCHANGE') {
+      if (
+        event.data.type === 'REFUND/EXCHANGE' ||
+        event.data.type === 'REFRESH_REVIEW'
+      ) {
         hasFetched.current = false;
         setPage(1);
       }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/test -> main

## 변경 사항
후기 작성 시 주문 내역이 refresh 되지 않는 오류 해결
후기가 작성된 주문 내역에서 문의하기 버튼이 2개 뜨는 오류 해결

## 테스트 결과
![image](https://github.com/user-attachments/assets/2d6a6970-9f76-4b13-a324-76de83b8fd58)

## ETC

