### PR TITLE
[fix] refresh token이 필요한 API 요청에 쿠키 추가

### DIFF
--- a/dutchiepay/src/app/_components/_alarm/AlarmActiveAction.jsx
+++ b/dutchiepay/src/app/_components/_alarm/AlarmActiveAction.jsx
@@ -1,6 +1,7 @@
 'use client';
-import useReissueToken from '@/app/hooks/useReissueToken';
+
 import axios from 'axios';
+import useReissueToken from '@/app/hooks/useReissueToken';
 import { useSelector } from 'react-redux';
 
 export default function AlarmActiveAction({

--- a/dutchiepay/src/app/hooks/useLogin.jsx
+++ b/dutchiepay/src/app/hooks/useLogin.jsx
@@ -19,11 +19,12 @@ export default function useLogin() {
       const expires = isRemeberMe
         ? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
         : undefined;
+      const isLocalhost = window.location.hostname === 'localhost';
       cookies.set('refresh', refresh, {
         path: '/',
         expires,
-        domain: '.dutchie-pay.site',
-        secure: true,
+        domain: isLocalhost ? undefined : '.dutchie-pay.site',
+        secure: !isLocalhost,
         sameSite: 'None',
       });
     }

--- a/dutchiepay/src/app/hooks/useReissueToken.jsx
+++ b/dutchiepay/src/app/hooks/useReissueToken.jsx
@@ -15,12 +15,15 @@ const useReissueToken = () => {
         `${process.env.NEXT_PUBLIC_BASE_URL}/users/reissue`,
         {
           access: accessToken,
+        },
+        {
+          withCredentials: true,
         }
       );
 
       dispatch(setAccessToken({ access: response.data.access }));
 
-      return { success: true }; // 새 액세스 토큰 반환
+      return { success: true };
     } catch (error) {
       let message;
       if (error.response) {
@@ -39,7 +42,7 @@ const useReissueToken = () => {
     }
   }, [accessToken, dispatch, clearUserData]);
 
-  return { refreshAccessToken }; // 함수 반환
+  return { refreshAccessToken };
 };
 
 export default useReissueToken;

--- a/dutchiepay/src/app/hooks/useRelogin.jsx
+++ b/dutchiepay/src/app/hooks/useRelogin.jsx
@@ -13,7 +13,11 @@ export default function useRelogin() {
 
     try {
       const response = await axios.post(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`
+        `${process.env.NEXT_PUBLIC_BASE_URL}/users/relogin`,
+        {},
+        {
+          withCredentials: true,
+        }
       );
 
       const userInfo = {


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/test -> main

## 변경 사항
refresh token이 필요한 요청 (relogin, reissue)에 withCredentials 설정을 추가했습니다.

## 테스트 결과
요청 시 쿠키가 전달됩니다.

## ETC

