### PR TITLE
[feat] 로그인 시 이전 페이지로 redirect

### DIFF
--- a/dutchiepay/src/app/(routes)/community/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/[id]/page.jsx
@@ -13,6 +13,7 @@ import { useSelector } from 'react-redux';
 export default function CommunityDetail() {
   const { id } = useParams();
   const access = useSelector((state) => state.login.access);
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const [post, setPost] = useState(null);
   const router = useRouter();
   const hasFetched = useRef(false);
@@ -54,8 +55,9 @@ export default function CommunityDetail() {
         }
       }
     };
+    if (!isLoggedIn) return;
     fetchCommunityDetail();
-  }, [id, access, router, refreshAccessToken]);
+  }, [id, access, router, refreshAccessToken, isLoggedIn]);
 
   return (
     <ProtectedRoute>

--- a/dutchiepay/src/app/(routes)/community/page.jsx
+++ b/dutchiepay/src/app/(routes)/community/page.jsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { usePathname, useSearchParams } from 'next/navigation';
+
 import CommunityPostList from '@/app/_components/_community/CommunityPostList';
 import FreeCommunityFilter from '@/app/_components/_community/_free/FreeCommunityFilter';
 import Link from 'next/link';
 import PostSearch from '@/app/_components/_community/_common/PostSearch';
-import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
@@ -14,6 +15,7 @@ export default function Community() {
   const [filter, setFilter] = useState('최신순');
   const category = params.get('category');
   const [keyword, setKeyword] = useState('');
+  const pathname = usePathname();
 
   return (
     <section className="min-h-[750px] w-[1020px] mb-[100px]">
@@ -22,7 +24,7 @@ export default function Community() {
         <div className="flex items-end gap-[24px]">
           <FreeCommunityFilter filter={filter} setFilter={setFilter} />
           <Link
-            href={`${isLoggedIn ? '/community/write' : '/login'}`}
+            href={`${isLoggedIn ? '/community/write' : `/login?redirect=${encodeURIComponent(pathname)}`}`}
             className="text-white rounded bg-blue--500 px-[16px] py-[8px] text-sm"
             role="button"
           >

--- a/dutchiepay/src/app/(routes)/help/page.jsx
+++ b/dutchiepay/src/app/(routes)/help/page.jsx
@@ -5,7 +5,7 @@ import more from '../../../../public/image/more.svg';
 import { useState } from 'react';
 
 export default function Help() {
-  const [openIndexes, setOpenIndexes] = useState(Array(10).fill(false)); // 토글 상태
+  const [openIndexes, setOpenIndexes] = useState(Array(10).fill(false));
 
   const handleToggle = (index) => {
     setOpenIndexes((prevState) => {

--- a/dutchiepay/src/app/(routes)/mart/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/[id]/page.jsx
@@ -14,6 +14,7 @@ import { useSelector } from 'react-redux';
 export default function MartDetail() {
   const { id } = useParams();
   const access = useSelector((state) => state.login.access);
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const [post, setPost] = useState(null);
   const router = useRouter();
   const { refreshAccessToken } = useReissueToken();
@@ -55,9 +56,9 @@ export default function MartDetail() {
         }
       }
     };
-
+    if (!isLoggedIn) return;
     fetchMartDetail();
-  }, [id, access, router, refreshAccessToken]);
+  }, [id, access, router, refreshAccessToken, isLoggedIn]);
   return (
     <ProtectedRoute>
       <section className="min-h-[750px] w-[1020px]">

--- a/dutchiepay/src/app/(routes)/mart/page.jsx
+++ b/dutchiepay/src/app/(routes)/mart/page.jsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { usePathname, useSearchParams } from 'next/navigation';
+
 import Link from 'next/link';
 import MartPostList from '@/app/_components/_community/_local/MartPostList';
 import PostSearch from '@/app/_components/_community/_common/PostSearch';
-import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
@@ -12,13 +13,14 @@ export default function Mart() {
   const params = useSearchParams();
   const category = params.get('category');
   const [keyword, setKeyword] = useState('');
+  const pathname = usePathname();
 
   return (
     <section className="min-h-[750px] w-[1020px] mb-[100px]">
       <div className="mt-[60px] flex justify-between">
         <PostSearch setKeyword={setKeyword} />
         <Link
-          href={`${isLoggedIn ? '/mart/write' : '/login'}`}
+          href={`${isLoggedIn ? '/mart/write' : `/login?redirect=${encodeURIComponent(pathname)}`}`}
           className="text-white rounded bg-blue--500 px-[16px] py-[8px] text-sm"
           role="button"
         >

--- a/dutchiepay/src/app/(routes)/order/page.jsx
+++ b/dutchiepay/src/app/(routes)/order/page.jsx
@@ -20,6 +20,7 @@ export default function Order() {
       alert('구매 가능 수량은 1개부터 99개까지입니다.');
       router.push('/');
     }
+
     const handleMessage = (event) => {
       const allowedOrigins = [process.env.NEXT_PUBLIC_BASE_URL];
 

--- a/dutchiepay/src/app/(routes)/used/[id]/page.jsx
+++ b/dutchiepay/src/app/(routes)/used/[id]/page.jsx
@@ -14,6 +14,7 @@ import { useSelector } from 'react-redux';
 export default function TradeDetail() {
   const { id } = useParams();
   const access = useSelector((state) => state.login.access);
+  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const [post, setPost] = useState(null);
   const router = useRouter();
   const { refreshAccessToken } = useReissueToken();
@@ -51,8 +52,9 @@ export default function TradeDetail() {
       }
     };
 
+    if (!isLoggedIn) return;
     fetchTradeDetail();
-  }, [id, access, router, refreshAccessToken]);
+  }, [id, access, router, refreshAccessToken, isLoggedIn]);
 
   return (
     <ProtectedRoute>

--- a/dutchiepay/src/app/(routes)/used/page.jsx
+++ b/dutchiepay/src/app/(routes)/used/page.jsx
@@ -1,16 +1,17 @@
 'use client';
 
+import { usePathname, useSearchParams } from 'next/navigation';
+
 import Link from 'next/link';
 import PostSearch from '@/app/_components/_community/_common/PostSearch';
 import TradePostList from '@/app/_components/_community/_local/TradePostList';
-import { useSearchParams } from 'next/navigation';
 import { useSelector } from 'react-redux';
 import { useState } from 'react';
 
 export default function Used() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
   const params = useSearchParams();
-
+  const pathname = usePathname();
   const category = params.get('category');
   const [keyword, setKeyword] = useState('');
 
@@ -20,7 +21,7 @@ export default function Used() {
         <PostSearch setKeyword={setKeyword} />
         <div className="flex items-end gap-[24px]">
           <Link
-            href={`${isLoggedIn ? '/used/write' : '/login'}`}
+            href={`${isLoggedIn ? '/used/write' : `/login?redirect=${encodeURIComponent(pathname)}`}`}
             className="text-white rounded bg-blue--500 px-[16px] py-[8px] text-sm"
             role="button"
           >

--- a/dutchiepay/src/app/_components/ProtectedRoute.jsx
+++ b/dutchiepay/src/app/_components/ProtectedRoute.jsx
@@ -1,18 +1,20 @@
 'use client';
 
+import { usePathname, useRouter } from 'next/navigation';
+
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
 const ProtectedRoute = ({ children }) => {
   const router = useRouter();
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!isLoggedIn) {
-      router.replace('/login');
+      router.replace(`/login?redirect=${encodeURIComponent(pathname)}`);
     }
-  }, [isLoggedIn, router]);
+  }, [isLoggedIn, router, pathname]);
 
   // 로그인이 되어 있으면 자식 컴포넌트를 렌더링
   if (!isLoggedIn) {

--- a/dutchiepay/src/app/_components/_commerce/_productDetail/OrderButton.jsx
+++ b/dutchiepay/src/app/_components/_commerce/_productDetail/OrderButton.jsx
@@ -1,22 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useSelector } from 'react-redux';
 
 export default function OrderButton({ isEnd, productId, quantity, product }) {
-  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
-  const router = useRouter();
-
   const handleOrder = (e) => {
-    if (!isLoggedIn) {
-      e.preventDefault();
-      router.push('/login');
-      return;
-    }
-
     if (isEnd) {
       e.preventDefault(); // 마감됐을 경우, Link 동작되지 않도록 기본 동작 제거
+      return;
     }
 
     if (quantity === '') {

--- a/dutchiepay/src/app/_components/_community/_free/FreePostItem.jsx
+++ b/dutchiepay/src/app/_components/_community/_free/FreePostItem.jsx
@@ -6,14 +6,11 @@ import Link from 'next/link';
 import comment from '/public/image/comment.svg';
 import community from '/public/image/community.jpg';
 import profile from '/public/image/profile.jpg';
-import { useSelector } from 'react-redux';
 
 export default function FreePostItem({ item }) {
-  const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
-
   return (
     <Link
-      href={`${isLoggedIn ? `/community/${item.freeId}` : '/login'}`}
+      href={`/community/${item.freeId}`}
       className="w-[240px] border rounded-xl flex flex-col gap-[4px] cursor-pointer"
     >
       <div className="rounded-t-xl h-[160px] overflow-hidden relative ">

--- a/dutchiepay/src/app/_components/_community/_local/MartPostItem.jsx
+++ b/dutchiepay/src/app/_components/_community/_local/MartPostItem.jsx
@@ -7,14 +7,16 @@ import location from '/public/image/location.svg';
 import mart from '/public/image/mart.jpg';
 import people from '/public/image/people.svg';
 import profile from '/public/image/profile.jpg';
+import { usePathname } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
 export default function MartPostItem({ item }) {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const pathname = usePathname();
 
   return (
     <Link
-      href={`${isLoggedIn ? `/mart/${item.shareId}` : '/login'}`}
+      href={`${isLoggedIn ? `/mart/${item.shareId}` : `/login?redirect=${encodeURIComponent(pathname)}`}`}
       className="w-[240px] border rounded-xl flex flex-col gap-[4px] cursor-pointer"
     >
       <div className="rounded-t-xl h-[160px] relative overflow-hidden ">

--- a/dutchiepay/src/app/_components/_community/_local/TradePostItem.jsx
+++ b/dutchiepay/src/app/_components/_community/_local/TradePostItem.jsx
@@ -6,15 +6,17 @@ import location from '/public/image/location.svg';
 import money from '/public/image/money.svg';
 import product from '/public/image/product.svg';
 import profile from '/public/image/profile.jpg';
+import { usePathname } from 'next/navigation';
 import { useSelector } from 'react-redux';
 import used from '/public/image/used.jpg';
 
 export default function TradePostItem({ item }) {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const pathname = usePathname();
 
   return (
     <Link
-      href={`${isLoggedIn ? `/used/${item.purchaseId}` : '/login'}`}
+      href={`${isLoggedIn ? `/used/${item.purchaseId}` : `/login?redirect=${encodeURIComponent(pathname)}`}`}
       className="w-[240px] border rounded-xl flex flex-col gap-[4px] cursor-pointer"
     >
       <div className="rounded-t-xl h-[160px] relative overflow-hidden">

--- a/dutchiepay/src/app/_components/_layout/HeaderTop.jsx
+++ b/dutchiepay/src/app/_components/_layout/HeaderTop.jsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import useLogout from '@/app/hooks/useLogout';
+import { usePathname } from 'next/navigation';
 import { useSelector } from 'react-redux';
 
 export default function HeaderTop() {
@@ -9,6 +10,7 @@ export default function HeaderTop() {
   const user = useSelector((state) => state.login.user);
   let accessToken = useSelector((state) => state.login.access);
   const handleLogout = useLogout(accessToken);
+  const pathname = usePathname();
 
   return (
     <ul className="flex justify-end items-center mt-[4px] gap-[6px]">
@@ -32,11 +34,6 @@ export default function HeaderTop() {
               마이페이지
             </Link>
           </li>
-          <li className="header-nav-item">
-            <Link href="/help" className="text-xs hover:underline">
-              고객센터
-            </Link>
-          </li>
         </>
       ) : (
         <>
@@ -46,17 +43,20 @@ export default function HeaderTop() {
             </Link>
           </li>
           <li className="header-nav-item">
-            <Link href="/login" className="text-xs hover:underline">
+            <Link
+              href={`/login?redirect=${encodeURIComponent(pathname)}`}
+              className="text-xs hover:underline"
+            >
               로그인
-            </Link>
-          </li>
-          <li className="header-nav-item">
-            <Link href="/help" className="text-xs hover:underline">
-              고객센터
             </Link>
           </li>
         </>
       )}
+      <li className="header-nav-item">
+        <Link href="/help" className="text-xs hover:underline">
+          고객센터
+        </Link>
+      </li>
     </ul>
   );
 }

--- a/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
@@ -14,7 +14,6 @@ export default function LoginSubmit() {
   const router = useRouter();
   const param = useSearchParams();
   const handleLogin = useLogin();
-
   const [isRemeberMe, setIsRememberMe] = useState(false); // 자동로그인 체크 여부
   const [isUnauthorized, setIsUnauthorized] = useState(false);
 

--- a/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
+++ b/dutchiepay/src/app/_components/_user/_login/LoginSubmit.jsx
@@ -1,16 +1,18 @@
 'use client';
 
+import { useRouter, useSearchParams } from 'next/navigation';
+
 import LoginButton from './LoginButton';
 import LoginInput from './LoginInput';
 import RememberMe from './RememberMe';
 import axios from 'axios';
 import { useForm } from 'react-hook-form';
 import useLogin from '@/app/hooks/useLogin';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function LoginSubmit() {
   const router = useRouter();
+  const param = useSearchParams();
   const handleLogin = useLogin();
 
   const [isRemeberMe, setIsRememberMe] = useState(false); // 자동로그인 체크 여부
@@ -52,7 +54,7 @@ export default function LoginSubmit() {
         isRemeberMe,
         refresh: response.data.refresh,
       });
-      router.push('/');
+      router.push(`${param ? decodeURIComponent(param.get('redirect')) : '/'}`);
     } catch (error) {
       if (error.response.data.message === '해당하는 유저가 없습니다.')
         setIsUnauthorized(true);

--- a/dutchiepay/src/app/hooks/useOauthLogin.jsx
+++ b/dutchiepay/src/app/hooks/useOauthLogin.jsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import CryptoJS from 'crypto-js';
 import useLogin from './useLogin';
-import { useRouter } from 'next/navigation';
 
 export default function useOAuthLogin() {
   const router = useRouter();
+  const param = useSearchParams();
   const handleLogin = useLogin();
 
   const handleMessage = useCallback(
@@ -44,10 +45,12 @@ export default function useOAuthLogin() {
           isRemeberMe: false,
           refresh: extracted.refresh,
         });
-        router.push('/');
+        router.push(
+          `${param ? decodeURIComponent(param.get('redirect')) : '/'}`
+        );
       }
     },
-    [handleLogin, router]
+    [handleLogin, router, param]
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/login-redirect -> main

## 변경 사항
로그인 시 메인페이지가 아닌 이전 페이지로 redirect가 가능하도록 login URL에 redirect query를 추가하였습니다.
Protected Route로 인해 비회원이 게시글 상세페이지를 접근할 경우 로그인되는 로직 중 게시글 상세페이지 내 fetch 코드가 먼저 동작하여 오류 반환 후 상세페이지로 이동되는 오류를 비회원일 경우 fetch를 진행하지 않도록 변경하여 해결

## 테스트 결과
![image](https://github.com/user-attachments/assets/ccdcf798-313a-44ab-ac62-3b5ef7f002ce)
소셜 로그인 동작 여부는 배포 후 테스트가 가능하여 생략

## ETC

