### PR TITLE
[fix] API routes를 이용하여 reversegeocoding 호출

### DIFF
--- a/dutchiepay/src/app/_util/getLocation.js
+++ b/dutchiepay/src/app/_util/getLocation.js
@@ -9,15 +9,7 @@ export default async function getLocation() {
 
           try {
             const response = await axios.get(
-              `/api/map-reversegeocode/gc?coords=${longitude},${latitude}&output=json`,
-              {
-                headers: {
-                  'X-NCP-APIGW-API-KEY-ID':
-                    process.env.NEXT_PUBLIC_MAP_CLIENT_ID,
-                  'X-NCP-APIGW-API-KEY':
-                    process.env.NEXT_PUBLIC_MAP_CLIENT_SECRET,
-                },
-              }
+              `/api/map-reversegeocode?coords=${longitude},${latitude}&output=json`
             );
 
             const area1 = response.data.results[0].region.area1.name;
@@ -30,7 +22,7 @@ export default async function getLocation() {
               location = `${area1} ${area2}`;
             } else {
               const area2Parts = area2.split(' ');
-              location = `${area2Parts[0]}`; // 첫 번째 부분만 사용
+              location = `${area2Parts[0]}`;
             }
 
             resolve(location);

--- a/dutchiepay/src/app/api/map-reversegeocode/route.js
+++ b/dutchiepay/src/app/api/map-reversegeocode/route.js
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url);
+  const coords = searchParams.get('coords');
+  const output = searchParams.get('output') || 'json';
+
+  if (!coords) {
+    return NextResponse.json(
+      { error: 'coords 파라미터가 필요합니다.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const response = await fetch(
+      `https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc?coords=${coords}&output=${output}`,
+      {
+        headers: {
+          'X-NCP-APIGW-API-KEY-ID': process.env.MAP_CLIENT_ID,
+          'X-NCP-APIGW-API-KEY': process.env.MAP_CLIENT_SECRET,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error('네이버 API 요청 실패');
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { error: '네이버 API 요청 중 오류 발생' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀️

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/security -> main

## 변경 사항
reversegeocoding을 클라이언트 단에서 호출하여 API 키가 노출되어 API routes로 호출 방식을 변경하였습니다.

## 테스트 결과
localhost를 서비스 URL에서 제거하기 전까지는 동작하는 걸 확인했으나 URL을 제거하여 배포 서비스에서만 동작을 확인할 수 있어 배포 후문제 체크하겠습니다.

## ETC
payment와 map 렌더링 API 호출 시 키가 노출되어 해당 부분 수정하려고 하였으나 SDK는 클라이언트 단에서만 동작하여 API routes를 이용할 수 없고 지도 렌더링는 client_id를 노출시키지 않을 방법이 없다고 하여 localhost를 제거하는 방향으로 1차 처리하려고 합니다. 이후 방법을 찾게 되면 해당 부분 수정할 예정입니다. 일단 가장 문제가 되는 부분부터 처리하여 PR 올립니다.